### PR TITLE
Fix Pioneer/MTF running-history dedupe collisions

### DIFF
--- a/server/parser.ts
+++ b/server/parser.ts
@@ -246,11 +246,20 @@ function normalizeClaimLifecycle(claimTypeValue: any, currentStatusValue: any): 
   return currentStatus ? 'other_inactive' : 'active';
 }
 
-function pioneerClaimKey(claim: Pick<PioneerClaim, 'pharmacyCode' | 'rxNumber' | 'fillNumber' | 'ndc'>) {
-  return [claim.pharmacyCode, claim.rxNumber, claim.fillNumber, cleanNdc(claim.ndc)].join('|');
+function pioneerClaimKey(claim: Pick<PioneerClaim, 'pharmacyCode' | 'rxNumber' | 'fillNumber' | 'ndc' | 'fillDate' | 'claimDate' | 'claimStatus' | 'currentTransactionStatus'>) {
+  return [
+    claim.pharmacyCode,
+    claim.rxNumber,
+    claim.fillNumber,
+    cleanNdc(claim.ndc),
+    claim.fillDate || '',
+    claim.claimDate || '',
+    asText(claim.claimStatus).toUpperCase(),
+    asText(claim.currentTransactionStatus).toLowerCase(),
+  ].join('|');
 }
 
-function mtfClaimKey(claim: Pick<MtfClaim, 'sourceType' | 'pharmacyCode' | 'rxNumber' | 'fillNumber' | 'ndc' | 'icn' | 'receiptDate' | 'rawPaymentAmount'>) {
+function mtfClaimKey(claim: Pick<MtfClaim, 'sourceType' | 'pharmacyCode' | 'rxNumber' | 'fillNumber' | 'ndc' | 'icn' | 'serviceDate' | 'receiptDate' | 'rawPaymentAmount'>) {
   return [
     claim.sourceType,
     claim.pharmacyCode,
@@ -258,6 +267,7 @@ function mtfClaimKey(claim: Pick<MtfClaim, 'sourceType' | 'pharmacyCode' | 'rxNu
     claim.fillNumber,
     cleanNdc(claim.ndc),
     claim.icn || '',
+    claim.serviceDate || '',
     claim.receiptDate || '',
     claim.rawPaymentAmount ?? '',
   ].join('|');


### PR DESCRIPTION
### Motivation
- Audit found running-history overwrite was caused by coarse dedupe keys used by `mergeByKey`, causing distinct Pioneer/MTF rows to collide and replace prior history.  
- The intent is to preserve a running history for Pioneer claims, MTF payments, and MTF adjustments while keeping inventory/price uploads as overwrite-only and preserving manual clear, drilldown, and local-only behavior.

### Description
- Exact files changed: `server/parser.ts`.  
- Adjusted dedupe keys used for running-history datasets: Pioneer key now includes `fillDate`, `claimDate`, `claimStatus`, and `currentTransactionStatus` in addition to `pharmacyCode|rxNumber|fillNumber|ndc`, and MTF key now includes `serviceDate` in addition to the prior fields; this prevents distinct historical rows from collapsing.  
- Preserved overwrite-only behavior for inventory and price files and left `clearDataset`, drilldown, and local storage logic unchanged.  
- Change is a minimal, localized fix limited to the parser's key generation used by `mergeByKey`.

### Testing
- Ran type-checking with `npm run check` and the build with `npm run build`; both completed successfully.  
- No automated end-to-end ingest replay was executed in this environment; logic change is limited to key generation and compilation was verified.  
- Remaining risks: dedupe is still key-based so rows identical across the expanded key will still dedupe, and preserved history may increase stored row counts over time (intended behavior to avoid overwrite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3ac221d8832e98dbd4cfbe00dd74)