### PR TITLE
Centralize claim lifecycle logic, refactor callers, and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "tsx --test server/claimLifecycle.test.ts"
   },
   "dependencies": {
     "express": "^5.1.0",

--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -1,4 +1,5 @@
 import { PHARMACIES, readDb } from './data';
+import { classifyClaimLifecycle, isInactiveClaim } from './claimLifecycle';
 import { buildStaffingState } from './staffing';
 import type { MtfClaim, PharmacyCode, PioneerClaim, PriceRow } from './types';
 
@@ -39,22 +40,12 @@ function cleanNdc(ndc: string | null | undefined) {
   return String(ndc || '').replace(/[^0-9]/g, '');
 }
 
-function isInactiveLifecycle(claim: Pick<PioneerClaim, 'normalizedClaimLifecycle' | 'claimStatus' | 'currentTransactionStatus'>) {
-  const lifecycle = String(claim.normalizedClaimLifecycle || '').toLowerCase();
-  if (['reversed', 'cancelled', 'rejected_on_hold', 'transferred', 'other_inactive'].includes(lifecycle)) return true;
-  const claimType = String(claim.claimStatus || '').toUpperCase();
-  const currentStatus = String(claim.currentTransactionStatus || '').toLowerCase();
-  if (claimType === 'B2') return true;
-  if (/cancel|reverse|reject|hold|transfer/.test(currentStatus)) return true;
-  return false;
-}
-
 function activeClaimsOnly<T extends PioneerClaim>(claims: T[]) {
-  return claims.filter((claim) => !isInactiveLifecycle(claim));
+  return claims.filter((claim) => !isInactiveClaim(claim));
 }
 
 function countLifecycle(claims: PioneerClaim[], lifecycle: PioneerClaim['normalizedClaimLifecycle']) {
-  return claims.filter((claim) => claim.normalizedClaimLifecycle === lifecycle).length;
+  return claims.filter((claim) => classifyClaimLifecycle(claim) === lifecycle).length;
 }
 
 const MEDICAID_PLAN_NAMES = [

--- a/server/claimLifecycle.test.ts
+++ b/server/claimLifecycle.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyClaimLifecycle, isInactiveClaim, normalizeClaimLifecycle } from './claimLifecycle';
+
+test('normalizeClaimLifecycle marks B2 as reversed', () => {
+  assert.equal(normalizeClaimLifecycle({ claimStatus: 'B2', currentTransactionStatus: null }), 'reversed');
+});
+
+test('normalizeClaimLifecycle maps blank claim type + cancelled to rejected_on_hold', () => {
+  assert.equal(normalizeClaimLifecycle({ claimStatus: '', currentTransactionStatus: 'Cancelled' }), 'rejected_on_hold');
+});
+
+test('classifyClaimLifecycle uses raw status signals over stored normalized lifecycle', () => {
+  assert.equal(classifyClaimLifecycle({ claimStatus: 'B2', currentTransactionStatus: 'Completed', normalizedClaimLifecycle: 'active' }), 'reversed');
+});
+
+test('classifyClaimLifecycle falls back to stored normalized lifecycle when raw signals are missing', () => {
+  assert.equal(classifyClaimLifecycle({ claimStatus: '', currentTransactionStatus: '', normalizedClaimLifecycle: 'transferred' }), 'transferred');
+});
+
+test('isInactiveClaim excludes transferred and allows active claims', () => {
+  assert.equal(isInactiveClaim({ claimStatus: '', currentTransactionStatus: 'Transferred' }), true);
+  assert.equal(isInactiveClaim({ claimStatus: 'B1', currentTransactionStatus: 'Completed' }), false);
+});

--- a/server/claimLifecycle.ts
+++ b/server/claimLifecycle.ts
@@ -1,0 +1,49 @@
+import type { PioneerClaim } from './types';
+
+export type ClaimLifecycle = PioneerClaim['normalizedClaimLifecycle'];
+
+type LifecycleInput = {
+  claimStatus?: string | null;
+  currentTransactionStatus?: string | null;
+  normalizedClaimLifecycle?: ClaimLifecycle | null;
+};
+
+function asText(value: string | null | undefined): string {
+  return String(value ?? '').trim();
+}
+
+function includesAny(text: string, pattern: RegExp): boolean {
+  return pattern.test(text);
+}
+
+function isKnownLifecycle(value: string): value is ClaimLifecycle {
+  return ['active', 'reversed', 'cancelled', 'rejected_on_hold', 'transferred', 'other_inactive'].includes(value);
+}
+
+export function normalizeClaimLifecycle(input: Pick<LifecycleInput, 'claimStatus' | 'currentTransactionStatus'>): ClaimLifecycle {
+  const claimType = asText(input.claimStatus).toUpperCase();
+  const claimTypeText = claimType.toLowerCase();
+  const currentStatus = asText(input.currentTransactionStatus).toLowerCase();
+  const combined = `${claimTypeText} ${currentStatus}`.trim();
+
+  if (claimType === 'B2' || includesAny(combined, /reversal|reversed|reverse/)) return 'reversed';
+  if (includesAny(combined, /transfer|transferred/)) return 'transferred';
+  if (includesAny(currentStatus, /cancel/) && !claimType) return 'rejected_on_hold';
+  if (includesAny(combined, /reject|on hold|hold/)) return 'rejected_on_hold';
+  if (includesAny(combined, /cancel|cancelled/)) return 'cancelled';
+  if (claimType === 'B1' || includesAny(combined, /complete|completed|paid|sold|adjudicated/)) return 'active';
+  return combined ? 'other_inactive' : 'active';
+}
+
+export function classifyClaimLifecycle(input: LifecycleInput): ClaimLifecycle {
+  const hasRawLifecycleSignals = asText(input.claimStatus) !== '' || asText(input.currentTransactionStatus) !== '';
+  if (hasRawLifecycleSignals) {
+    return normalizeClaimLifecycle(input);
+  }
+  const normalized = String(input.normalizedClaimLifecycle || '').toLowerCase();
+  return isKnownLifecycle(normalized) ? normalized : 'active';
+}
+
+export function isInactiveClaim(input: LifecycleInput): boolean {
+  return classifyClaimLifecycle(input) !== 'active';
+}

--- a/server/parser.ts
+++ b/server/parser.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import xlsx from 'xlsx';
 import { randomUUID } from 'node:crypto';
 import { pharmacyByCode, readDb, resolvePharmacy, writeDb } from './data';
+import { normalizeClaimLifecycle } from './claimLifecycle';
 import type { InventoryGroup, InventoryRow, MtfClaim, PharmacyCode, PioneerClaim, PriceRow, UploadType } from './types';
 
 type RowObject = Record<string, any>;
@@ -233,19 +234,6 @@ function asDate(value: any): string | null {
   return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString().slice(0, 10);
 }
 
-function normalizeClaimLifecycle(claimTypeValue: any, currentStatusValue: any): 'active' | 'reversed' | 'cancelled' | 'rejected_on_hold' | 'transferred' | 'other_inactive' {
-  const claimType = asText(claimTypeValue).toUpperCase();
-  const currentStatus = asText(currentStatusValue).toLowerCase();
-
-  if (claimType === 'B2' || /reversal|reversed/.test(currentStatus)) return 'reversed';
-  if (/transfer|transferred/.test(currentStatus)) return 'transferred';
-  if (/cancel/.test(currentStatus) && !claimType) return 'rejected_on_hold';
-  if (/reject|on hold|hold/.test(currentStatus)) return 'rejected_on_hold';
-  if (/cancel/.test(currentStatus)) return 'cancelled';
-  if (claimType === 'B1' || /complete|completed|paid|sold|adjudicated/.test(currentStatus)) return 'active';
-  return currentStatus ? 'other_inactive' : 'active';
-}
-
 function pioneerClaimKey(claim: Pick<PioneerClaim, 'pharmacyCode' | 'rxNumber' | 'fillNumber' | 'ndc'>) {
   return [claim.pharmacyCode, claim.rxNumber, claim.fillNumber, cleanNdc(claim.ndc)].join('|');
 }
@@ -441,7 +429,7 @@ export function ingestUpload(filePath: string, type: UploadType, requestedPharma
         payerType: payerTypeFromNames(primaryPayer, thirdPartyName || '', primaryPlanType || '', secondaryPlanType || ''),
         claimStatus,
         currentTransactionStatus,
-        normalizedClaimLifecycle: normalizeClaimLifecycle(rawClaimStatus, currentTransactionStatus),
+        normalizedClaimLifecycle: normalizeClaimLifecycle({ claimStatus: rawClaimStatus, currentTransactionStatus }),
         totalPricePaid: asNumber(findValue(row, ['TotalPricePaid', 'Total Price Paid', 'Paid Amount', 'Gross Amount'])),
         primaryRemitAmount: asNumber(findValue(row, ['PrimaryRemit', 'PrimaryRemitAmount', 'Primary Remit', 'Primary Remit Amount', 'Remit Amount', 'Net Paid'])),
         secondaryRemitAmount: asNumber(findValue(row, ['SecondaryRemit', 'SecondaryRemitAmount', 'Secondary Remit', 'Secondary Remit Amount'])),


### PR DESCRIPTION
### Motivation

- Consolidate and standardize claim lifecycle classification and active/inactive detection into a single module to avoid duplicated logic and subtle inconsistencies.

### Description

- Add `server/claimLifecycle.ts` which implements `normalizeClaimLifecycle`, `classifyClaimLifecycle`, and `isInactiveClaim` to centralize lifecycle logic and export the `ClaimLifecycle` type.
- Refactor `server/analysis.ts` to import and use `classifyClaimLifecycle` and `isInactiveClaim` instead of local inline logic for lifecycle classification and active-claim filtering.
- Refactor `server/parser.ts` to import and call the new `normalizeClaimLifecycle` signature (object param) rather than its previous local implementation and remove the duplicate function.
- Add unit tests in `server/claimLifecycle.test.ts` and a `test` script to `package.json` (`tsx --test server/claimLifecycle.test.ts`).

### Testing

- Added `server/claimLifecycle.test.ts` covering normalization, classification precedence, fallback behavior, and `isInactiveClaim` and ran it via `npm test` (`tsx --test server/claimLifecycle.test.ts`), which succeeded.
- Ran the TypeScript type check via `npm run check` (`tsc --noEmit`), which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3d251d90832eb79f2bafa87e6497)