### PR TITLE
Add SDRA overview totals (expected, actual, variance)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -668,6 +668,9 @@ export default function App() {
               subtitle="Monitor RX collectible gap, improper 340B payment exposure, pending items, and unexpected payment rows from MTF plus adjustment uploads."
               color={sectionColorMap.SDRA}
               metrics={[
+                { label: 'Total expected', value: state.sdraSummary?.totalExpected || 0, type: 'currency', tone: 'neutral' },
+                { label: 'Total actual', value: state.sdraSummary?.totalActual || 0, type: 'currency', tone: 'neutral' },
+                { label: 'Total variance', value: state.sdraSummary?.totalVariance || 0, type: 'currency', tone: (state.sdraSummary?.totalVariance || 0) > 0 ? 'good' : (state.sdraSummary?.totalVariance || 0) < 0 ? 'bad' : 'neutral' },
                 { label: 'Should have been paid and was paid', value: state.sdraSummary?.shouldHaveBeenPaidAndWasPaid || 0, type: 'currency', tone: 'good' },
                 { label: 'Should not have been paid and was paid', value: state.sdraSummary?.shouldNotHaveBeenPaidAndWasPaid || 0, type: 'currency', tone: 'bad', onClick: () => setReportContext({ section: 'SDRA', filterText: '340B', flaggedOnly: true }) },
                 { label: 'Correctly paid', value: state.sdraSummary?.correctlyPaidAmount || 0, type: 'currency', tone: 'good' },


### PR DESCRIPTION
### Motivation
- Audit confirmed SDRA eligibility is Pioneer-based (`Med D` + SDRA-reference NDC) and MTF/MTF-adjustment rows remain the payment source, and the backend already computed aggregate SDRA totals but the SDRA overview cards did not surface them; this PR exposes those aggregates in the UI.

### Description
- UI-only change: added three metrics to the SDRA `SectionOverview` in `App.tsx` bound to `state.sdraSummary`: `totalExpected`, `totalActual`, and `totalVariance`; no backend logic, matching, or drilldown behavior was modified (file changed: `App.tsx`).

### Testing
- Ran `npm run check` (TypeScript compile) and `npm run build` (vite production build); both completed successfully; visual/browser runtime checks were not performed here and should be spot-checked in-app for layout or tone issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3fe06098832ebe2952088a524882)