### PR TITLE
Reduce day-supply false positives for stock-size package cycles

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -194,6 +194,26 @@ function isLikelyPackagedInjectableClaim(
   return quantity <= 12;
 }
 
+function isLikelyStockSizeCycleClaim(
+  claim: PioneerClaim,
+  stockSizeMap: ReturnType<typeof buildStockSizeMap>,
+) {
+  const quantity = Number(claim.quantity || 0);
+  const daysSupply = Number(claim.daysSupply || 0);
+  if (!quantity || !daysSupply || !isCommonPackageDaysSupply(daysSupply)) return false;
+
+  const stockSize = stockSizeMap.exact.get(`${claim.pharmacyCode}|${cleanNdc(claim.ndc)}`)
+    ?? stockSizeMap.anyGroup.get(`${claim.pharmacyCode}|${cleanNdc(claim.ndc)}`)
+    ?? 0;
+  if (stockSize <= 0) return false;
+
+  const multiplier = quantity / stockSize;
+  const roundedMultiplier = Math.round(multiplier);
+  if (roundedMultiplier >= 1 && roundedMultiplier <= 4 && Math.abs(multiplier - roundedMultiplier) <= 0.05) return true;
+  if (Math.abs(multiplier - 0.5) <= 0.05 || Math.abs(multiplier - 1.5) <= 0.05 || Math.abs(multiplier - 2.5) <= 0.05) return true;
+  return false;
+}
+
 function hasAtypicalDaySupply(
   claim: PioneerClaim,
   stockSizeMap: ReturnType<typeof buildStockSizeMap>,
@@ -206,6 +226,7 @@ function hasAtypicalDaySupply(
   if (isVariableDosePackageClaim(claim, stockSizeMap, inventoryReferenceMap)) return false;
   const unitsPerDay = quantity / daysSupply;
   if (unitsPerDay < 0.35 && isLikelyPackagedInjectableClaim(claim, stockSizeMap, inventoryReferenceMap)) return false;
+  if (unitsPerDay < 0.35 && isLikelyStockSizeCycleClaim(claim, stockSizeMap)) return false;
   if (isPackageSensitiveDaySupplyClaim(claim, inventoryReferenceMap) && unitsPerDay < 0.35 && isCommonPackageDaysSupply(daysSupply)) return false;
   return unitsPerDay < 0.35 || unitsPerDay > 4.5;
 }


### PR DESCRIPTION
### Motivation
- Audit found noisy day-supply flagging logic in `server/analysis.ts` that still produced false positives for package-dispensed and variable-dose injectable items despite an existing 7/14/28 stock-size exception.  
- The intent is to reduce false positives for package-based injectable and stock-size items while preserving the existing one-stock-size exception and the rest of Claims Analysis behavior.  

### Description
- Changed `server/analysis.ts` by adding `isLikelyStockSizeCycleClaim` and calling it from `hasAtypicalDaySupply` to suppress low-units/day flags when quantity aligns to stock-size multiples for common package days-supply windows.  
- Preserved the existing `isOneStockSizeCycle` 7/14/28 exception and the other package-sensitive injectable logic (`isLikelyPackagedInjectableClaim`) and did not alter the core atypical threshold checks.  
- Exact file modified: `server/analysis.ts`.  
- Remaining risks: the stock-size-multiple heuristic may still miss rare real anomalies that mimic package cycles and there are no dedicated unit tests in-repo for this new helper path.  

### Testing
- Ran type-check with `npm run check` and it completed successfully.  
- Built the client with `npm run build` and the build completed successfully.  
- No automated unit tests exist for the new helper; validation here is compile/build verification only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb41708018832eb35a1a3246328206)