### PR TITLE
Add SFTP import, resilient inbox/file handling, and DB backup/restore

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -106,6 +106,7 @@ export default function App() {
   const [message, setMessage] = useState('');
   const [uploadForm, setUploadForm] = useState<{ type: UploadType; pharmacyCode: string }>({ type: 'pioneer', pharmacyCode: 'SEMINOLE' });
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
+  const [sftpForm, setSftpForm] = useState({ host: '', port: '22', username: '', password: '', remoteDir: '.' });
   const [userForm, setUserForm] = useState({ username: '', password: '', displayName: '', role: 'viewer' });
   const [reportContext, setReportContext] = useState<{ section?: Section; filterText?: string; flaggedOnly?: boolean }>({});
   const isGlobalPriceUpload = uploadForm.type === 'price_rx' || uploadForm.type === 'price_340b';
@@ -158,22 +159,31 @@ export default function App() {
     if (!uploadQueue.length) return setMessage('No queued files to upload');
     let successCount = 0;
     const notes: string[] = [];
+    const failedItems: UploadQueueItem[] = [];
     for (const item of uploadQueue) {
-      const fd = new FormData();
-      fd.append('file', item.file);
-      fd.append('type', item.type);
-      if (!isGlobalUpload(item.type)) fd.append('pharmacyCode', item.pharmacyCode);
-      const res = await fetch('/api/upload', { method: 'POST', body: fd });
-      const data = await res.json();
-      if (res.ok) {
-        successCount += 1;
-        notes.push(`${item.file.name}: ${data.rows}/${data.sourceRows}`);
-      } else {
-        notes.push(`${item.file.name}: ${data.message || 'Upload failed'}`);
+      try {
+        const fd = new FormData();
+        fd.append('file', item.file);
+        fd.append('type', item.type);
+        if (!isGlobalUpload(item.type)) fd.append('pharmacyCode', item.pharmacyCode);
+        const res = await fetch('/api/upload', { method: 'POST', body: fd });
+        const data = await res.json();
+        if (res.ok) {
+          successCount += 1;
+          notes.push(`${item.file.name}: ${data.rows}/${data.sourceRows}`);
+        } else {
+          failedItems.push(item);
+          notes.push(`${item.file.name}: ${data.message || 'Upload failed'}`);
+        }
+      } catch {
+        failedItems.push(item);
+        notes.push(`${item.file.name}: Upload request failed`);
       }
     }
-    setUploadQueue([]);
-    setMessage(`${successCount} of ${notes.length} queued files uploaded · ${notes.join(' | ')}`);
+    setUploadQueue(failedItems);
+    const failedCount = notes.length - successCount;
+    const retryNote = failedCount ? ` · ${failedCount} kept in queue for retry` : '';
+    setMessage(`${successCount} of ${notes.length} queued files uploaded${retryNote} · ${notes.join(' | ')}`);
     loadState();
   }
 
@@ -198,9 +208,33 @@ export default function App() {
     const res = await fetch('/api/inbox/scan', { method: 'POST' });
     const data = await res.json();
     if (!res.ok) return setMessage(data.message || 'Inbox scan failed');
-    const note = `${data.importedCount || 0} imported`;
-    const rejected = data.rejectedCount ? ` · ${data.rejectedCount} rejected` : '';
-    setMessage(`Inbox scan complete: ${note}${rejected}`);
+    const imported = data.importedCount || 0;
+    const rejectedCount = data.rejectedCount || 0;
+    const rejectedSummary = rejectedCount
+      ? ` · rejected: ${(data.rejected || []).slice(0, 3).map((item: any) => `${item.file} (${item.reason})`).join('; ')}`
+      : '';
+    setMessage(`Inbox scan complete: ${imported} imported, ${rejectedCount} rejected${rejectedSummary}`);
+    loadState();
+  }
+
+  async function importFromSftp() {
+    const res = await fetch('/api/inbox/sftp-import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        host: sftpForm.host,
+        port: Number(sftpForm.port || 22),
+        username: sftpForm.username,
+        password: sftpForm.password,
+        remoteDir: sftpForm.remoteDir,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) return setMessage(data.message || 'SFTP import failed');
+    const imported = data.importedCount || 0;
+    const rejected = data.rejectedCount || 0;
+    const downloaded = data.downloadedCount || 0;
+    setMessage(`SFTP import complete: ${downloaded} downloaded · ${imported} imported · ${rejected} rejected`);
     loadState();
   }
 
@@ -640,6 +674,17 @@ export default function App() {
                 </div>
                 <div className="row" style={{ marginTop: 14 }}>
                   <button className="primary" type="button" onClick={scanInbox}>Scan inbox now</button>
+                </div>
+                <div style={{ marginTop: 16 }}>
+                  <div className="small-label">Import from SFTP credentials</div>
+                  <div className="form-grid" style={{ marginTop: 8 }}>
+                    <input placeholder="Host" value={sftpForm.host} onChange={(e) => setSftpForm({ ...sftpForm, host: e.target.value })} />
+                    <input placeholder="Port" value={sftpForm.port} onChange={(e) => setSftpForm({ ...sftpForm, port: e.target.value })} />
+                    <input placeholder="Username" value={sftpForm.username} onChange={(e) => setSftpForm({ ...sftpForm, username: e.target.value })} />
+                    <input placeholder="Password" type="password" value={sftpForm.password} onChange={(e) => setSftpForm({ ...sftpForm, password: e.target.value })} />
+                    <input placeholder="Remote folder" value={sftpForm.remoteDir} onChange={(e) => setSftpForm({ ...sftpForm, remoteDir: e.target.value })} />
+                    <button className="secondary" type="button" onClick={importFromSftp}>Pull and scan</button>
+                  </div>
                 </div>
               </div>
               <div className="card section-card">

--- a/server/data.ts
+++ b/server/data.ts
@@ -14,6 +14,7 @@ const appDir = path.resolve(process.cwd(), 'app_data');
 const uploadsDir = path.resolve(process.cwd(), 'uploads');
 export const ingestInboxDir = path.resolve(process.cwd(), 'ingest_inbox');
 const dbFile = path.join(appDir, 'db.json');
+const dbBackupFile = `${dbFile}.bak`;
 
 function createDefaultDb(): AppDb {
   return {
@@ -41,7 +42,20 @@ function ensure() {
 
 export function readDb(): AppDb {
   ensure();
-  const parsed = JSON.parse(fs.readFileSync(dbFile, 'utf8')) as Partial<AppDb>;
+  let parsed: Partial<AppDb>;
+  try {
+    parsed = JSON.parse(fs.readFileSync(dbFile, 'utf8')) as Partial<AppDb>;
+  } catch (primaryError) {
+    if (!fs.existsSync(dbBackupFile)) throw new Error('Unable to read local database file');
+    try {
+      parsed = JSON.parse(fs.readFileSync(dbBackupFile, 'utf8')) as Partial<AppDb>;
+    } catch {
+      throw new Error('Unable to read local database file or backup');
+    }
+    const tempFile = `${dbFile}.tmp`;
+    fs.writeFileSync(tempFile, JSON.stringify(parsed), 'utf8');
+    fs.renameSync(tempFile, dbFile);
+  }
   return {
     ...createDefaultDb(),
     ...parsed,
@@ -58,6 +72,17 @@ export function readDb(): AppDb {
 
 export function writeDb(db: AppDb) {
   ensure();
+  if (fs.existsSync(dbFile)) {
+    try {
+      JSON.parse(fs.readFileSync(dbFile, 'utf8'));
+      const backupTempFile = `${dbBackupFile}.tmp`;
+      fs.copyFileSync(dbFile, backupTempFile);
+      fs.renameSync(backupTempFile, dbBackupFile);
+    } catch {
+      // Keep last known good backup if the current db file is unreadable.
+    }
+  }
+
   const tempFile = `${dbFile}.tmp`;
   fs.writeFileSync(tempFile, JSON.stringify(db), 'utf8');
   fs.renameSync(tempFile, dbFile);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import multer from 'multer';
 import path from 'node:path';
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import { addUser, clearDataset, ingestInboxDir, PHARMACIES, pharmacyByCode, readDb, saveUpload, setReviewDecision } from './data';
 import { ingestUpload } from './parser';
 import { getAppState } from './analysis';
@@ -74,8 +75,21 @@ function parseInboxAssignment(fileName: string): { type: UploadType; pharmacyCod
   if (!type) return null;
   if (type === 'price_rx' || type === 'price_340b') return { type };
 
-  const pharmacyCode = resolveInboxPharmacy(tokens[0] || '');
-  return pharmacyCode ? { type, pharmacyCode } : null;
+  const pharmacyMatches = detectInboxPharmacyMatches(tokens);
+  if (pharmacyMatches.length !== 1) return null;
+  return { type, pharmacyCode: pharmacyMatches[0] };
+}
+
+function detectInboxPharmacyMatches(tokens: string[]): PharmacyCode[] {
+  const set = new Set(tokens.map((token) => token.trim().toLowerCase()).filter(Boolean));
+  const matches = new Set<PharmacyCode>();
+
+  if (set.has('mv') || set.has('montevista') || (set.has('monte') && set.has('vista'))) matches.add('MONTE_VISTA');
+  if (set.has('arlington')) matches.add('ARLINGTON');
+  if (set.has('konawa')) matches.add('KONAWA');
+  if (set.has('seminole')) matches.add('SEMINOLE');
+
+  return [...matches];
 }
 
 function scanInbox() {
@@ -100,7 +114,7 @@ function scanInbox() {
     const storedPath = path.join(uploadDir, storedName);
 
     try {
-      fs.renameSync(sourcePath, storedPath);
+      moveFile(sourcePath, storedPath);
       const result = ingestUpload(storedPath, assignment.type, assignment.pharmacyCode);
       saveUpload(
         { originalname: originalName, filename: storedName } as Express.Multer.File,
@@ -122,7 +136,7 @@ function scanInbox() {
       });
     } catch (error: any) {
       if (fs.existsSync(storedPath) && !fs.existsSync(sourcePath)) {
-        fs.renameSync(storedPath, sourcePath);
+        moveFile(storedPath, sourcePath);
       }
       rejected.push({ file: originalName, reason: error?.message || 'Inbox import failed' });
     }
@@ -135,6 +149,81 @@ function scanInbox() {
     rejectedCount: rejected.length,
     imported,
     rejected,
+  };
+}
+
+function moveFile(sourcePath: string, destinationPath: string) {
+  try {
+    fs.renameSync(sourcePath, destinationPath);
+  } catch (error: any) {
+    if (error?.code !== 'EXDEV') throw error;
+    fs.copyFileSync(sourcePath, destinationPath);
+    fs.unlinkSync(sourcePath);
+  }
+}
+
+async function pullInboxFromSftp(input: {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  remoteDir: string;
+}) {
+  const downloaded: string[] = [];
+  fs.mkdirSync(ingestInboxDir, { recursive: true });
+
+  const credentials = `${input.username}:${input.password}`;
+  const normalizeRemoteDir = (input.remoteDir || '.').replace(/\\/g, '/').replace(/\/+$/, '');
+  const encodeRemotePath = (remotePath: string) => remotePath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+  const basePath = normalizeRemoteDir === '.' ? '' : normalizeRemoteDir;
+  const listUrl = `sftp://${input.host}:${input.port}/${encodeRemotePath(basePath)}`;
+
+  const listing = execFileSync('curl', [
+    '--silent',
+    '--show-error',
+    '--fail',
+    '--list-only',
+    '--user',
+    credentials,
+    listUrl,
+  ], { encoding: 'utf8' });
+
+  const remoteFiles = listing.split(/\r?\n/g).map((line) => line.trim()).filter(Boolean);
+  for (const remoteNameRaw of remoteFiles) {
+    const remoteName = path.basename(remoteNameRaw).trim();
+    if (!remoteName || remoteName.endsWith('/')) continue;
+    const ext = path.extname(remoteName).toLowerCase();
+    if (!['.xlsx', '.xls', '.csv'].includes(ext)) continue;
+
+    let localName = remoteName;
+    let index = 1;
+    while (fs.existsSync(path.join(ingestInboxDir, localName))) {
+      const parsed = path.parse(remoteName);
+      localName = `${parsed.name}_${index}${parsed.ext}`;
+      index += 1;
+    }
+
+    const localPath = path.join(ingestInboxDir, localName);
+    const remotePath = [basePath, remoteNameRaw].filter(Boolean).join('/');
+    const remoteUrl = `sftp://${input.host}:${input.port}/${encodeRemotePath(remotePath)}`;
+    execFileSync('curl', [
+      '--silent',
+      '--show-error',
+      '--fail',
+      '--user',
+      credentials,
+      '--output',
+      localPath,
+      remoteUrl,
+    ], { encoding: 'utf8' });
+    downloaded.push(localName);
+  }
+
+  const scanResult = scanInbox();
+  return {
+    downloadedCount: downloaded.length,
+    downloaded,
+    ...scanResult,
   };
 }
 
@@ -181,6 +270,9 @@ export function registerRoutes(app: express.Express) {
       saveUpload(req.file, type, pharmacyCode || 'ALL', result.impactedPharmacies, result.rows, result.sourceRows, result.rejectedRows, result.sheetName);
       res.json({ ok: true, ...result });
     } catch (error: any) {
+      if (req.file?.path && fs.existsSync(req.file.path)) {
+        fs.unlinkSync(req.file.path);
+      }
       res.status(400).json({ message: error?.message || 'Upload failed' });
     }
   });
@@ -190,6 +282,24 @@ export function registerRoutes(app: express.Express) {
       res.json({ ok: true, ...scanInbox() });
     } catch (error: any) {
       res.status(400).json({ message: error?.message || 'Inbox scan failed' });
+    }
+  });
+
+  app.post('/api/inbox/sftp-import', express.json(), async (req, res) => {
+    try {
+      const host = typeof req.body?.host === 'string' ? req.body.host.trim() : '';
+      const username = typeof req.body?.username === 'string' ? req.body.username.trim() : '';
+      const password = typeof req.body?.password === 'string' ? req.body.password : '';
+      const remoteDir = typeof req.body?.remoteDir === 'string' && req.body.remoteDir.trim() ? req.body.remoteDir.trim() : '.';
+      const requestedPort = Number(req.body?.port);
+      const port = Number.isFinite(requestedPort) && requestedPort > 0 ? requestedPort : 22;
+      if (!host || !username || !password) {
+        return res.status(400).json({ message: 'host, username, and password are required for SFTP import' });
+      }
+      const result = await pullInboxFromSftp({ host, port, username, password, remoteDir });
+      res.json({ ok: true, ...result });
+    } catch (error: any) {
+      res.status(400).json({ message: error?.message || 'SFTP import failed' });
     }
   });
 


### PR DESCRIPTION
### Motivation
- Provide a way to pull files from an SFTP server into the local ingest workflow and present credentials in the UI for operators to trigger remote pulls.
- Make inbox file moves and parsing more robust across filesystems and ambiguous filenames so valid files are not rejected unnecessarily.
- Improve resilience of the on-disk database by keeping/using a backup when the primary DB is corrupted and creating safe backups on write.

### Description
- Frontend: added `sftpForm` state, UI inputs for SFTP credentials, and `importFromSftp` which calls a new `/api/inbox/sftp-import` endpoint, and improved inbox scan messaging; enhanced `uploadQueuedFiles` to retain failed items in the queue and report retry info.
- Server routes: added `/api/inbox/sftp-import` that invokes `pullInboxFromSftp`, and hardened `/api/upload` to remove uploaded temp files on error; introduced `moveFile` helper to handle cross-device moves and reuse across inbox scanning.
- Inbox parsing: replaced simple pharmacy resolution with `detectInboxPharmacyMatches` and require a single unambiguous match to accept an inbox file; scan logic now uses `moveFile` and reports imported/rejected details.
- SFTP pull: implemented `pullInboxFromSftp` which uses `curl` (via `execFileSync`) to list and download remote files into the local `ingest_inbox` and then invokes the existing inbox scan.
- DB safety: on read, if the primary DB JSON is unreadable attempt to load `${dbFile}.bak` and restore it atomically; on write create/rotate a backup `${dbFile}.bak` safely when the current DB is readable.

### Testing
- Ran the project test suite via `npm test` and the suite completed successfully.
- Performed automated smoke/integration checks for inbox scanning and upload endpoints by exercising `/api/inbox/scan`, `/api/upload`, and `/api/inbox/sftp-import` (simulated), and observed expected responses.
- Verified that corrupting the main DB file triggers fallback to the `.bak` file and that writes produce a `.bak` backup as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb4aebd6b8832e8d4a00ffa6f189d6)