### PR TITLE
Improve Medicaid detection and refine 340B prescriber eligibility logic

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -57,19 +57,33 @@ function countLifecycle(claims: PioneerClaim[], lifecycle: PioneerClaim['normali
   return claims.filter((claim) => claim.normalizedClaimLifecycle === lifecycle).length;
 }
 
-const MEDICAID_PLAN_NAMES = [
-  'ohca',
-  'oklahoma health care authority',
+const MEDICAID_CONTEXT_MARKERS = ['medicaid', 'soonercare', 'welfare', 'ohca', 'oklahoma health care authority'] as const;
+const MEDICAID_MCO_EXACT_MARKERS = [
   'aetna better health of oklahoma medicaid mco',
   'oklahoma complete health (centene) medicaid mco 2hfa',
-  'humana health horizons ok medicaid mco 1a791',
-  'soonercare',
-  'medicaid'
-];
+  'humana health horizons ok medicaid mco 1a791'
+] as const;
+const MEDICAID_MCO_SHORT_MARKERS = [
+  'aetna better health of oklahoma',
+  'oklahoma complete health (centene)',
+  'oklahoma complete health',
+  'humana health horizons ok'
+] as const;
+
+function normalizeMedicaidText(value: string | null | undefined) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
 
 function includesMedicaidMarker(value: string | null | undefined) {
-  const text = String(value || '').toLowerCase();
-  return MEDICAID_PLAN_NAMES.some((marker) => text.includes(marker)) || /medicaid|soonercare|welfare/.test(text);
+  const text = normalizeMedicaidText(value);
+  if (!text) return false;
+
+  if (MEDICAID_CONTEXT_MARKERS.some((marker) => text.includes(marker))) return true;
+  if (MEDICAID_MCO_EXACT_MARKERS.some((marker) => text.includes(normalizeMedicaidText(marker)))) return true;
+
+  const hasShortMcoName = MEDICAID_MCO_SHORT_MARKERS.some((marker) => text.includes(normalizeMedicaidText(marker)));
+  const hasMedicaidContext = /\b(medicaid|mco|soonercare|ohca|oklahoma health care authority)\b/.test(text);
+  return hasShortMcoName && hasMedicaidContext;
 }
 
 function isMedicaidClaim(claim: PioneerClaim) {
@@ -990,8 +1004,8 @@ export function getAppState(pharmacyCode?: PharmacyCode) {
     const prescriberCategory = (claim.prescriberCategory || '').toLowerCase();
     const diabeticSupply = /test strip|lancet|sensor|meter|cgms|dexcom|freestyle|pen needle|needle/i.test(claim.drugName);
     const medicaidClaim = isMedicaidClaim(claim);
-    const is340BEligible = /340b referral|340b/i.test(prescriberCategory);
     const isReferral = /340b referral/i.test(prescriberCategory);
+    const isConfirmed340BEligible = /(^|\b)340b(\b|$)/i.test(prescriberCategory) && !isReferral;
     let finding: string | null = null;
     let severity: 'high' | 'medium' | 'low' = 'low';
     let flagged = true;
@@ -999,14 +1013,14 @@ export function getAppState(pharmacyCode?: PharmacyCode) {
     if (medicaidClaim && claim.inventoryGroup === '340B') {
       finding = 'Medicaid plan dispensed from 340B inventory';
       severity = 'high';
-    } else if (claim.inventoryGroup === '340B' && !is340BEligible) {
+    } else if (claim.inventoryGroup === '340B' && !isConfirmed340BEligible && !isReferral) {
       finding = '340B inventory used without 340B-eligible prescriber';
       severity = 'high';
     } else if (claim.inventoryGroup === '340B' && isReferral) {
       finding = '340B referral verification queue';
       severity = 'low';
       flagged = false;
-    } else if (claim.inventoryGroup === 'RX' && is340BEligible && !diabeticSupply && !medicaidClaim) {
+    } else if (claim.inventoryGroup === 'RX' && isConfirmed340BEligible && !diabeticSupply && !medicaidClaim) {
       finding = 'RX inventory used for 340B-eligible prescriber';
       severity = 'medium';
     }

--- a/server/parser.ts
+++ b/server/parser.ts
@@ -272,16 +272,40 @@ function inventoryGroup(value: any): InventoryGroup {
   return String(value ?? '').toUpperCase().includes('340') ? '340B' : 'RX';
 }
 
+function normalizeMedicaidText(value: string | null | undefined): string {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+const MEDICAID_CONTEXT_MARKERS = ['medicaid', 'soonercare', 'welfare', 'ohca', 'oklahoma health care authority'] as const;
+const MEDICAID_MCO_EXACT_MARKERS = [
+  'aetna better health of oklahoma medicaid mco',
+  'oklahoma complete health (centene) medicaid mco 2hfa',
+  'humana health horizons ok medicaid mco 1a791'
+] as const;
+const MEDICAID_MCO_SHORT_MARKERS = [
+  'aetna better health of oklahoma',
+  'oklahoma complete health (centene)',
+  'oklahoma complete health',
+  'humana health horizons ok'
+] as const;
+
+function isMedicaidNameMatch(...names: string[]): boolean {
+  const combined = normalizeMedicaidText(names.join(' '));
+  if (!combined) return false;
+
+  if (MEDICAID_CONTEXT_MARKERS.some((marker) => combined.includes(marker))) return true;
+  if (MEDICAID_MCO_EXACT_MARKERS.some((marker) => combined.includes(normalizeMedicaidText(marker)))) return true;
+
+  const hasShortMcoName = MEDICAID_MCO_SHORT_MARKERS.some((marker) => combined.includes(normalizeMedicaidText(marker)));
+  const hasMedicaidContext = /\b(medicaid|mco|soonercare|ohca|oklahoma health care authority)\b/.test(combined);
+  return hasShortMcoName && hasMedicaidContext;
+}
+
 function payerTypeFromNames(...names: string[]): PioneerClaim['payerType'] {
   const combined = names.join(' ').toLowerCase();
   if (!combined) return 'Other';
   if (combined.includes('cash') || combined.includes('self-pay') || combined.includes('rx cash')) return 'Cash';
-  if (
-    combined.includes('medicaid') || combined.includes('soonercare') || combined.includes('welfare') || combined.includes('ohca')
-    || combined.includes('aetna better health of oklahoma medicaid mco')
-    || combined.includes('oklahoma complete health (centene) medicaid mco 2hfa')
-    || combined.includes('humana health horizons ok medicaid mco 1a791')
-  ) return 'Medicaid';
+  if (isMedicaidNameMatch(...names)) return 'Medicaid';
   if (combined.includes('pdp') || combined.includes('med d') || combined.includes('part d') || combined.includes('mapd') || combined.includes('medicare')) return 'Med D';
   if (combined.includes('commercial') || combined.includes('standard') || combined.includes('coupon') || combined.includes('340b')) return 'Commercial';
   return 'Commercial';


### PR DESCRIPTION
### Motivation

- Make Medicaid payer detection more accurate by normalizing names and matching both full MCO markers and short MCO names only when a Medicaid context is present.  
- Reduce false positives for 340B prescriber eligibility by distinguishing explicit referrals from confirmed 340B indicators.  

### Description

- Add `normalizeMedicaidText` and new marker lists (`MEDICAID_CONTEXT_MARKERS`, `MEDICAID_MCO_EXACT_MARKERS`, `MEDICAID_MCO_SHORT_MARKERS`) and use them in both `server/analysis.ts` and `server/parser.ts` to centralize and normalize Medicaid name matching.  
- Replace simple substring checks with `includesMedicaidMarker` / `isMedicaidNameMatch` and update `payerTypeFromNames` and `isMedicaidClaim` to use the improved matching logic.  
- Introduce `isConfirmed340BEligible` (regex-based) and refine the compliance logic to treat `340b referral` differently, to avoid marking referrals or incidental matches as confirmed 340B eligibility.  
- Minor restructuring of constants and normalization logic to reduce duplication and improve matching reliability.  

### Testing

- Ran the test suite with `npm test` and all tests passed.  
- Performed type checking with `tsc --noEmit` and there were no type errors.  
- Ran linting with `npm run lint` and the code passed lint checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb50d9c82c832ea6583bc86c8f63e7)