### PR TITLE
Add dense ranking for third-party remit and gross profit and expose ranks in UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -339,8 +339,10 @@ export default function App() {
     { key: 'payerType', label: 'Type' },
     { key: 'totalClaims', label: 'Claims', type: 'number' },
     { key: 'medDClaims', label: 'Med D', type: 'number' },
+    { key: 'avgRemitPerRxRank', label: 'Remit Rank', type: 'number' },
     { key: 'avgRemitPerRx', label: 'Avg Remit/RX', type: 'currency' },
     { key: 'avgAcquisitionCostPerRx', label: 'Avg Acquisition/RX', type: 'currency' },
+    { key: 'grossProfitPerRxRank', label: 'GP Rank', type: 'number' },
     { key: 'grossProfitPerRx', label: 'Gross Profit/RX', type: 'currency' },
     { key: 'b340Rate', label: '340B Rate', type: 'percent' },
     { key: 'performanceFlag', label: 'Flag' },
@@ -730,7 +732,7 @@ export default function App() {
                 { label: 'Low GP', onClick: () => setReportContext({ section: 'Third Party', filterText: 'Low gross profit', flaggedOnly: false }), kind: 'secondary' },
               ]}
             />
-            <ReportTable title="Third-party analysis" description="Grouped by payer within each pharmacy, with row-level drilldown to the claims contributing to payer performance." rows={state.thirdParty} columns={thirdPartyColumns} exportName="third_party_analysis" onApplyLabel={saveReviewDecision} renderDetails={(row) => <DetailTable details={row.details} />} externalFilterText={visibleReportContext?.filterText} externalFlaggedOnly={visibleReportContext?.flaggedOnly} />
+            <ReportTable title="Third-party analysis" description="Grouped by payer within each pharmacy with finance-first ranking for remit and gross profit per RX, plus row-level drilldown to the claims behind each result." rows={state.thirdParty} columns={thirdPartyColumns} exportName="third_party_analysis" onApplyLabel={saveReviewDecision} renderDetails={(row) => <DetailTable details={row.details} />} externalFilterText={visibleReportContext?.filterText} externalFlaggedOnly={visibleReportContext?.flaggedOnly} />
           </>
         )}
 

--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -31,6 +31,27 @@ function sum(values: number[]) {
   return values.reduce((s, value) => s + value, 0);
 }
 
+function denseRank<T>(rows: T[], getValue: (row: T) => number | null | undefined, descending = true) {
+  const rankedRows = rows
+    .map((row) => ({ row, value: getValue(row) }))
+    .filter((entry) => entry.value != null && Number.isFinite(entry.value as number))
+    .sort((a, b) => descending
+      ? Number(b.value) - Number(a.value)
+      : Number(a.value) - Number(b.value));
+  const rankMap = new Map<T, number>();
+  let rank = 0;
+  let lastValue: number | null = null;
+  for (const entry of rankedRows) {
+    const currentValue = Number(entry.value);
+    if (lastValue == null || Math.abs(currentValue - lastValue) > 0.0001) {
+      rank += 1;
+      lastValue = currentValue;
+    }
+    rankMap.set(entry.row, rank);
+  }
+  return rankMap;
+}
+
 function money(value: number) {
   return Number(value.toFixed(2));
 }
@@ -756,7 +777,7 @@ export function getAppState(pharmacyCode?: PharmacyCode) {
 
   const thirdPartyClaims = pioneerClaims.filter((claim) => payerDisplayName(claim) !== 'Unknown' || claim.payerType === 'Cash');
   const payerGroups = Object.entries(groupBy(thirdPartyClaims, (claim) => `${claim.pharmacyCode}|${payerDisplayName(claim)}`));
-  const thirdPartyRaw = payerGroups.map(([groupKey, claims]) => {
+  const thirdPartyBase = payerGroups.map(([groupKey, claims]) => {
     const first = claims[0];
     const payer = payerDisplayName(first);
     const remitValues = claims.flatMap((claim) => {
@@ -817,7 +838,24 @@ export function getAppState(pharmacyCode?: PharmacyCode) {
         ])
       }
     };
-  }).sort((a, b) => Number(b.flagged) - Number(a.flagged) || (a.grossProfitPerRx ?? Infinity) - (b.grossProfitPerRx ?? Infinity) || b.totalClaims - a.totalClaims);
+  });
+  const remitRankMap = denseRank(thirdPartyBase, (row) => row.avgRemitPerRx, true);
+  const grossProfitRankMap = denseRank(thirdPartyBase, (row) => row.grossProfitPerRx, true);
+  const unrankedRemitPosition = remitRankMap.size + 1;
+  const unrankedGrossProfitPosition = grossProfitRankMap.size + 1;
+  const thirdPartyRaw = thirdPartyBase
+    .map((row) => ({
+      ...row,
+      avgRemitPerRxRank: remitRankMap.get(row) ?? unrankedRemitPosition,
+      grossProfitPerRxRank: grossProfitRankMap.get(row) ?? unrankedGrossProfitPosition,
+    }))
+    .sort((a, b) =>
+      Number(b.flagged) - Number(a.flagged)
+      || a.grossProfitPerRxRank - b.grossProfitPerRxRank
+      || a.avgRemitPerRxRank - b.avgRemitPerRxRank
+      || b.totalClaims - a.totalClaims
+      || a.payer.localeCompare(b.payer)
+    );
   const thirdParty = applyReviewDecisions(thirdPartyRaw, reviewDecisionMap);
 
   const inventoryByKey = Object.values(groupBy(inventoryRows, (row) => `${row.pharmacyCode}|${row.ndc}`));


### PR DESCRIPTION
### Motivation
- Surface finance-first rankings for third-party payer groups so remit and gross-profit per-RX can be compared across payers. 
- Preserve sensible behavior for groups with missing data by assigning an unranked position when values are unavailable. 
- Make the third-party report UI show rank metadata and emphasize ranking in the table description. 

### Description
- Added a `denseRank` helper to `server/analysis.ts` to compute dense ranks over numeric metrics and return a `Map` of row -> rank. 
- Compute `remitRankMap` and `grossProfitRankMap` from the computed `avgRemitPerRx` and `grossProfitPerRx`, attach `avgRemitPerRxRank` and `grossProfitPerRxRank` to each third-party row, and use those ranks in the sort key with fallbacks for unranked rows. 
- Introduced `avgRemitPerRxRank` and `grossProfitPerRxRank` columns in `App.tsx` (`Remit Rank` and `GP Rank`) and updated the `Third-party analysis` `ReportTable` description to mention the finance-first ranking. 

### Testing
- Ran the TypeScript compiler with `tsc --noEmit` and the project type-check passed. 
- Ran the automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5420ae68832e80238c708ce16d8e)