### PR TITLE
Staffing: robust date parsing and RX/day weighting; UI label clarifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -390,7 +390,7 @@ export default function App() {
     { key: 'pharmacyName', label: 'Pharmacy' },
     { key: 'roleLabel', label: 'Role' },
     { key: 'rxRange', label: 'RX Range' },
-    { key: 'avgRxPerWeightedDay', label: 'RX / Day', type: 'number' },
+    { key: 'avgRxPerWeightedDay', label: 'RX/day', type: 'number' },
     { key: 'weightedOperatingDays', label: 'Weighted Days', type: 'number' },
     { key: 'allocated', label: 'Allocated', type: 'number' },
     { key: 'availableCoverage', label: 'Covered', type: 'number' },
@@ -457,7 +457,7 @@ export default function App() {
               <div>
                 <div className="eyebrow">Executive overview</div>
                 <h2>Financial control, compliance exposure, staffing pressure, and store action queues</h2>
-                <p>The dashboard is centered on modeled revenue, estimated acquisition, SDRA collectible gap, improper 340B payment exposure, inventory capital, and staffing capacity normalized to a 4.5-day operating week.</p>
+                <p>The dashboard is centered on modeled revenue, estimated acquisition, SDRA collectible gap, improper 340B payment exposure, inventory capital, and staffing capacity normalized to a 4.5-day operating week (Mon-Thu = 1.0 day each, Fri = 0.5 day).</p>
               </div>
               <div className="hero-points">
                 {topFindings.map((item) => <div key={item} className="hero-point">{item}</div>)}
@@ -508,10 +508,10 @@ export default function App() {
                 <div className="card section-card">
                   <div className="eyebrow">Staffing operating note</div>
                   <h3>4.5-day productivity normalization</h3>
-                  <p>Monday through Thursday count as 1.0 operating day and Friday counts as 0.5. RX/day is calculated from total observed claims divided by those weighted operating days, and staffing pressure is derived from that RX/day rate.</p>
+                  <p>Monday through Thursday count as 1.0 operating day and Friday counts as 0.5. RX/day is calculated from total observed claims divided by those weighted operating days, and staffing pressure is derived from that same RX/day rate.</p>
                   <div className="micro-metrics">
                     <MiniMetric label="Weighted operating days in data" value={staffingSummary.totalWeightedOperatingDays} />
-                    <MiniMetric label="RX / day" value={staffingSummary.overallAvgRxPerWeightedDay} />
+                    <MiniMetric label="RX/day" value={staffingSummary.overallAvgRxPerWeightedDay} />
                     <MiniMetric label="Open / exposed FTE" value={staffingSummary.totalOpenFte} />
                   </div>
                 </div>
@@ -806,15 +806,15 @@ export default function App() {
           <>
             <SectionOverview
               title="Staffing profile and workload capacity"
-              subtitle="Use the provided staffing profile, shared-seat rules, and a 4.5-day operating week to compare current coverage against observed RX/day demand and role-specific capacity ranges." 
+              subtitle="Use the provided staffing profile, shared-seat rules, and the 4.5-day operating standard (Mon-Thu = 1.0, Fri = 0.5) to compare current coverage against observed RX/day demand and role-specific capacity ranges." 
               color={sectionColorMap.Staffing}
               metrics={[
                 { label: 'Observed RX', value: staffingSummary.totalObservedRx || 0, type: 'number' },
-                { label: 'RX / day', value: staffingSummary.overallAvgRxPerWeightedDay || 0, type: 'number' },
+                { label: 'RX/day', value: staffingSummary.overallAvgRxPerWeightedDay || 0, type: 'number' },
                 { label: 'Allocated FTE', value: staffingSummary.totalAllocatedFte || 0, type: 'number' },
                 { label: 'Covered FTE', value: staffingSummary.totalFilledFte || 0, type: 'number' },
                 { label: 'Open / exposed FTE', value: staffingSummary.totalOpenFte || 0, type: 'number', tone: (staffingSummary.totalOpenFte || 0) > 0 ? 'warn' : 'good' },
-                { label: 'Pressure pharmacies', value: staffingSummary.pharmaciesWithPressure || 0, type: 'number', tone: (staffingSummary.pharmaciesWithPressure || 0) > 0 ? 'warn' : 'good' },
+                { label: 'RX/day pressure pharmacies', value: staffingSummary.pharmaciesWithPressure || 0, type: 'number', tone: (staffingSummary.pharmaciesWithPressure || 0) > 0 ? 'warn' : 'good' },
               ]}
               actions={[
                 { label: 'Only pressure roles', onClick: () => setReportContext({ section: 'Staffing', flaggedOnly: true }), kind: 'primary' },

--- a/server/staffing.ts
+++ b/server/staffing.ts
@@ -215,13 +215,49 @@ function money(value: number) {
   return Number(value.toFixed(2));
 }
 
-function operatingDayWeight(dateValue: string | null | undefined) {
-  if (!dateValue) return 0;
-  const date = new Date(dateValue);
-  if (Number.isNaN(date.getTime())) return 0;
-  const weekday = date.getUTCDay();
+function weekdayFromDateParts(year: number, month: number, day: number) {
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null;
+  if (year < 1900 || year > 3000) return null;
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  if (Number.isNaN(date.getTime())) return null;
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) return null;
+  return date.getUTCDay();
+}
+
+function weekdayWeight(weekday: number | null) {
+  if (weekday == null) return 0;
   if (weekday >= 1 && weekday <= 4) return 1;
   if (weekday === 5) return 0.5;
+  return 0;
+}
+
+function operatingDayWeight(dateValue: string | null | undefined) {
+  if (!dateValue) return 0;
+  const normalized = String(dateValue).trim();
+  if (!normalized) return 0;
+
+  // Parse date-only values explicitly to avoid timezone shifts.
+  const isoDateMatch = normalized.match(/^(\d{4})-(\d{1,2})-(\d{1,2})(?:$|[T\s])/);
+  if (isoDateMatch) {
+    const year = Number(isoDateMatch[1]);
+    const month = Number(isoDateMatch[2]);
+    const day = Number(isoDateMatch[3]);
+    return weekdayWeight(weekdayFromDateParts(year, month, day));
+  }
+
+  // Support common US date format exports (MM/DD/YYYY).
+  const usDateMatch = normalized.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (usDateMatch) {
+    const month = Number(usDateMatch[1]);
+    const day = Number(usDateMatch[2]);
+    const year = Number(usDateMatch[3]);
+    return weekdayWeight(weekdayFromDateParts(year, month, day));
+  }
+
+  // Unknown date format intentionally resolves to no weighted day so ambiguous parsing cannot skew staffing rates.
   return 0;
 }
 
@@ -258,11 +294,15 @@ function staffingNeed(avgRxPerWeightedDay: number, role: StaffingRoleKey) {
 }
 
 export function buildStaffingState(pioneerClaims: PioneerClaim[]) {
+  const rawWeightedOperatingByPharmacy: number[] = [];
   const perPharmacy = STAFFING_PROFILE.map((profile) => {
     const claims = pioneerClaims.filter((claim) => claim.pharmacyCode === profile.pharmacyCode);
     const operatingDates = [...new Set(claims.map((claim) => claim.fillDate || claim.claimDate).filter(Boolean) as string[])];
-    const weightedOperatingDays = round(operatingDates.reduce((sum, date) => sum + operatingDayWeight(date), 0));
-    const avgRxPerWeightedDay = weightedOperatingDays > 0 ? round(claims.length / weightedOperatingDays) : claims.length;
+    const rawWeightedOperatingDays = operatingDates.reduce((sum, date) => sum + operatingDayWeight(date), 0);
+    rawWeightedOperatingByPharmacy.push(rawWeightedOperatingDays);
+    const weightedOperatingDays = round(rawWeightedOperatingDays);
+    const rawAvgRxPerWeightedDay = rawWeightedOperatingDays > 0 ? claims.length / rawWeightedOperatingDays : claims.length;
+    const avgRxPerWeightedDay = round(rawAvgRxPerWeightedDay);
     const medDClaims = claims.filter((claim) => claim.payerType === 'Med D').length;
 
     const roleRows = profile.roles
@@ -275,7 +315,7 @@ export function buildStaffingState(pioneerClaims: PioneerClaim[]) {
         const shared = role.shared ?? 0;
         const availableCoverage = round(role.currentFilled + temporary + transitioningIn + shared - transitioningOut, 1);
         const openPositions = Math.max(round(role.allocated - availableCoverage, 1), 0);
-        const needs = staffingNeed(avgRxPerWeightedDay, role.key);
+        const needs = staffingNeed(rawAvgRxPerWeightedDay, role.key);
         const status = capacityStatus(availableCoverage, needs.stretchNeed, needs.preferredNeed);
         return {
           ...role,
@@ -329,7 +369,8 @@ export function buildStaffingState(pioneerClaims: PioneerClaim[]) {
   });
 
   const overallObservedRx = perPharmacy.reduce((sum, item) => sum + item.observedRx, 0);
-  const overallWeightedDays = round(perPharmacy.reduce((sum, item) => sum + item.weightedOperatingDays, 0));
+  const overallWeightedDaysRaw = rawWeightedOperatingByPharmacy.reduce((sum, value) => sum + value, 0);
+  const overallWeightedDays = round(overallWeightedDaysRaw);
   const overallAvgRxPerWeightedDay = overallWeightedDays > 0 ? round(overallObservedRx / overallWeightedDays) : overallObservedRx;
 
   return {


### PR DESCRIPTION
### Motivation
- Fix inaccurate RX/day and staffing needs caused by ambiguous or timezone-shifted date parsing and make the 4.5-day normalization language clearer in the UI. 
- Ensure staffing capacity math uses unrounded rates for need calculation while presenting rounded metrics to users.

### Description
- Replace fragile date parsing with `weekdayFromDateParts` and `weekdayWeight`, and enhance `operatingDayWeight` to explicitly parse ISO date-only (`YYYY-MM-DD`) and common US (`MM/DD/YYYY`) formats while returning 0 for unknown formats. 
- Preserve raw weighted operating-day totals per pharmacy (`rawWeightedOperatingByPharmacy`) and compute `rawAvgRxPerWeightedDay` for capacity math while presenting rounded `weightedOperatingDays` and `avgRxPerWeightedDay` to the UI. 
- Use the unrounded `rawAvgRxPerWeightedDay` when computing `staffingNeed` so stretch/preferred needs derive from the precise rate. 
- Update UI text and column/metric labels (e.g. `RX / Day` → `RX/day`, add explicit Mon-Thu/Fri weighting note, and rename some staffing metrics) for consistency and clarity.

### Testing
- Type-checking was verified with `tsc` and completed successfully. 
- Project unit tests were run with `npm test` and the existing test suite passed. 
- Linting was run with the repository linter and produced no new errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb58b6f21c832eb8214b047b4b2fb6)