### PR TITLE
Dashboard: add finance-first KPI header and compact currency formatting

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -464,15 +464,21 @@ export default function App() {
               </div>
             </div>
 
+            <div className="section-head" style={{ marginTop: 18 }}>
+              <div>
+                <div className="eyebrow">Finance-first dashboard KPIs</div>
+                <h3>Profitability and exposure at a glance</h3>
+              </div>
+            </div>
             <div className="grid executive-kpi-grid">
-              <ExecutiveKpi title="Recorded revenue" value={state.financeSummary?.recordedRevenue} type="currency" tone="neutral" onClick={() => openReport('Claims')} />
-              <ExecutiveKpi title="Modeled acquisition" value={state.financeSummary?.modeledAcquisition} type="currency" tone="neutral" onClick={() => openReport('Claims')} />
               <ExecutiveKpi title="Gross profit" value={state.financeSummary?.grossProfit} type="currency" tone={(state.financeSummary?.grossProfit || 0) >= 0 ? 'good' : 'bad'} onClick={() => openReport('Third Party')} />
               <ExecutiveKpi title="Gross margin" value={state.financeSummary?.grossMargin} type="percent" tone={(state.financeSummary?.grossMargin || 0) >= 0 ? 'good' : 'bad'} onClick={() => openReport('Third Party')} />
+              <ExecutiveKpi title="Recorded revenue" value={state.financeSummary?.recordedRevenue} type="currency" tone="neutral" onClick={() => openReport('Claims')} />
+              <ExecutiveKpi title="Modeled acquisition" value={state.financeSummary?.modeledAcquisition} type="currency" tone="neutral" onClick={() => openReport('Claims')} />
               <ExecutiveKpi title="SDRA collectible gap" value={state.financeSummary?.sdraCollectibleGap} type="currency" tone={(state.financeSummary?.sdraCollectibleGap || 0) > 0 ? 'warn' : 'good'} onClick={() => openReport('SDRA', { flaggedOnly: true })} />
               <ExecutiveKpi title="340B payment exposure" value={state.financeSummary?.improper340BExposure} type="currency" tone={(state.financeSummary?.improper340BExposure || 0) > 0 ? 'bad' : 'good'} onClick={() => openReport('340B', { flaggedOnly: true })} />
-              <ExecutiveKpi title="Weighted NDC savings" value={state.financeSummary?.weightedNdcSavings} type="currency" tone={(state.financeSummary?.weightedNdcSavings || 0) > 0 ? 'good' : 'neutral'} onClick={() => openReport('NDC', { flaggedOnly: true })} />
               <ExecutiveKpi title="Inventory value" value={state.financeSummary?.totalInventoryValue} type="currency" tone="neutral" onClick={() => openReport('Inventory')} />
+              <ExecutiveKpi title="Weighted NDC savings" value={state.financeSummary?.weightedNdcSavings} type="currency" tone={(state.financeSummary?.weightedNdcSavings || 0) > 0 ? 'good' : 'neutral'} onClick={() => openReport('NDC', { flaggedOnly: true })} />
             </div>
 
             <div className="grid two-col" style={{ marginTop: 18 }}>
@@ -890,12 +896,18 @@ export default function App() {
 
 
 function ExecutiveKpi({ title, value, type, tone = 'neutral', onClick }: { title:string; value:any; type?:ColumnDef['type']; tone?:'neutral'|'good'|'warn'|'bad'; onClick?:()=>void }) {
-  const renderedValue = formatCell(value, type);
+  const numericValue = Number(value || 0);
+  const isLargeCurrency = type === 'currency' && Math.abs(numericValue) >= 1000000;
+  const renderedValue = isLargeCurrency
+    ? new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 1 }).format(numericValue)
+    : formatCell(value, type);
+  const fullValue = isLargeCurrency ? formatCell(value, type) : '';
   const fitClass = renderedValue.length > 18 ? 'fit-xxs' : renderedValue.length > 15 ? 'fit-xs' : renderedValue.length > 12 ? 'fit-sm' : '';
   const content = (
     <>
       <div className="small-label">{title}</div>
       <div className={`executive-value ${fitClass}`}>{renderedValue}</div>
+      {fullValue && <div className="executive-subvalue">{fullValue}</div>}
     </>
   );
   return onClick ? (

--- a/styles.css
+++ b/styles.css
@@ -148,7 +148,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 }
 
 .grid { display: grid; gap: 16px; }
-.executive-kpi-grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); margin-top: 18px; }
+.executive-kpi-grid { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); margin-top: 8px; }
 .two-col { grid-template-columns: minmax(0, 1fr) minmax(340px, 420px); }
 .pharmacy-card-grid { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
 .metric-grid { display: grid; gap: 12px; }
@@ -158,7 +158,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 .executive-kpi {
   position: relative;
   overflow: hidden;
-  min-height: 126px;
+  min-height: 138px;
   background: linear-gradient(180deg, #fff, #f8fbff);
 }
 .executive-kpi::after {
@@ -185,6 +185,14 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 .executive-value.fit-sm { font-size: clamp(18px, 1.5vw, 26px); }
 .executive-value.fit-xs { font-size: clamp(16px, 1.35vw, 22px); }
 .executive-value.fit-xxs { font-size: clamp(14px, 1.15vw, 19px); }
+
+.executive-subvalue {
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.25;
+  font-variant-numeric: tabular-nums;
+}
 
 .action-grid { display: grid; gap: 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .action-card {
@@ -289,9 +297,13 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
   word-break: break-word;
 }
 .metric-value {
-  font-size: 18px;
+  font-size: clamp(15px, 1.05vw, 18px);
   font-weight: 700;
   margin-top: 4px;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  font-variant-numeric: tabular-nums;
 }
 
 button.primary,


### PR DESCRIPTION
### Motivation

- Surface finance-focused KPIs with a clear header and better grouping on the Dashboard for quicker executive consumption.
- Improve readability of very large currency values by showing a compact representation while preserving the full formatted value.
- Tweak KPI card sizing and spacing to accommodate the new subvalue and maintain visual balance.

### Description

- Added a new section header `Finance-first dashboard KPIs` above the executive KPI grid and adjusted the KPI ordering for emphasis. 
- Enhanced `ExecutiveKpi` to compact-format large currency values (>= 1,000,000) via `Intl.NumberFormat` with `notation: 'compact'` and display the full formatted value as a subvalue when compacted. 
- Updated layout and styling: increased `.executive-kpi` `min-height`, widened `.executive-kpi-grid` `minmax` to `240px`, added `.executive-subvalue` styles, and tuned `.metric-value` sizing and wrapping behavior in `styles.css`.

### Testing

- Built the app with `yarn build` and TypeScript compilation completed successfully. 
- Ran unit tests with `yarn test` and all tests passed. 
- Ran static checks with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbdc127c50832ea84b1eb9cdb92ff4)