### PR TITLE
Add local backup export and restore (client + server)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -106,6 +106,7 @@ export default function App() {
   const [message, setMessage] = useState('');
   const [uploadForm, setUploadForm] = useState<{ type: UploadType; pharmacyCode: string }>({ type: 'pioneer', pharmacyCode: 'SEMINOLE' });
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
+  const [restoreFile, setRestoreFile] = useState<File | null>(null);
   const [userForm, setUserForm] = useState({ username: '', password: '', displayName: '', role: 'viewer' });
   const [reportContext, setReportContext] = useState<{ section?: Section; filterText?: string; flaggedOnly?: boolean }>({});
   const isGlobalPriceUpload = uploadForm.type === 'price_rx' || uploadForm.type === 'price_340b';
@@ -191,6 +192,40 @@ export default function App() {
   async function clearDataset(dataset: string) {
     await fetch('/api/clear', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ dataset }) });
     setMessage(`Cleared ${dataset}`);
+    loadState();
+  }
+
+  async function exportLocalBackup() {
+    const res = await fetch('/api/backup/export');
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      return setMessage(data.message || 'Backup export failed');
+    }
+    const blob = await res.blob();
+    const disposition = res.headers.get('content-disposition') || '';
+    const match = /filename="([^"]+)"/i.exec(disposition);
+    const fileName = match?.[1] || `pharmacy-analytics-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json.gz`;
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+    setMessage('Local backup exported');
+  }
+
+  async function restoreLocalBackupFromFile() {
+    if (!restoreFile) return setMessage('Choose a local backup file first');
+    const proceed = window.confirm('Restore will replace current local data and uploaded files. Continue?');
+    if (!proceed) return;
+    const fd = new FormData();
+    fd.append('file', restoreFile);
+    const res = await fetch('/api/backup/restore', { method: 'POST', body: fd });
+    const data = await res.json();
+    if (!res.ok) return setMessage(data.message || 'Restore failed');
+    setRestoreFile(null);
+    setState(data.state || null);
+    setMessage('Local backup restored');
     loadState();
   }
 
@@ -640,6 +675,22 @@ export default function App() {
                 </div>
                 <div className="row" style={{ marginTop: 14 }}>
                   <button className="primary" type="button" onClick={scanInbox}>Scan inbox now</button>
+                </div>
+              </div>
+              <div className="card section-card">
+                <div className="eyebrow">Local backup</div>
+                <h3>Export and restore app data</h3>
+                <p className="section-copy">Backup and restore stay fully local. Export saves current app_data records plus uploaded source files into a single local JSON backup file. Restore replaces only local app data and does not change manual clear controls.</p>
+                <div className="row" style={{ marginTop: 12 }}>
+                  <button className="secondary" type="button" onClick={exportLocalBackup}>Export local backup</button>
+                </div>
+                <div className="form-grid" style={{ marginTop: 12 }}>
+                  <input
+                    type="file"
+                    accept=".json,.gz,.json.gz"
+                    onChange={(e) => setRestoreFile(e.target.files?.[0] || null)}
+                  />
+                  <button className="primary" type="button" onClick={restoreLocalBackupFromFile}>Restore backup</button>
                 </div>
               </div>
               <div className="card section-card">

--- a/server/data.ts
+++ b/server/data.ts
@@ -14,6 +14,27 @@ const appDir = path.resolve(process.cwd(), 'app_data');
 const uploadsDir = path.resolve(process.cwd(), 'uploads');
 export const ingestInboxDir = path.resolve(process.cwd(), 'ingest_inbox');
 const dbFile = path.join(appDir, 'db.json');
+const BACKUP_FORMAT_VERSION = 1;
+
+type BackupUploadFile = {
+  storedName: string;
+  originalName: string;
+  base64: string;
+};
+
+type LocalBackupPayload = {
+  type: 'pharmacy_analytics_backup';
+  formatVersion: number;
+  createdAt: string;
+  db: AppDb;
+  uploadFiles: BackupUploadFile[];
+};
+
+function assertSafeStoredName(storedName: string) {
+  if (!storedName || path.basename(storedName) !== storedName || storedName.includes('..')) {
+    throw new Error(`Invalid upload file name in backup data: ${storedName}`);
+  }
+}
 
 function createDefaultDb(): AppDb {
   return {
@@ -61,6 +82,96 @@ export function writeDb(db: AppDb) {
   const tempFile = `${dbFile}.tmp`;
   fs.writeFileSync(tempFile, JSON.stringify(db), 'utf8');
   fs.renameSync(tempFile, dbFile);
+}
+
+export function buildLocalBackup(): LocalBackupPayload {
+  const db = readDb();
+  const missingFiles: string[] = [];
+  const uploadFiles = db.uploads
+    .map((upload) => {
+      assertSafeStoredName(upload.storedName);
+      const full = path.join(uploadsDir, upload.storedName);
+      if (!fs.existsSync(full)) {
+        missingFiles.push(upload.originalName || upload.storedName);
+        return null;
+      }
+      const content = fs.readFileSync(full);
+      return {
+        storedName: upload.storedName,
+        originalName: upload.originalName,
+        base64: content.toString('base64'),
+      };
+    })
+    .filter(Boolean) as BackupUploadFile[];
+
+  if (missingFiles.length) {
+    throw new Error(`Backup export blocked: ${missingFiles.length} uploaded file(s) are missing locally`);
+  }
+
+  return {
+    type: 'pharmacy_analytics_backup',
+    formatVersion: BACKUP_FORMAT_VERSION,
+    createdAt: new Date().toISOString(),
+    db,
+    uploadFiles,
+  };
+}
+
+function normalizeDb(input: Partial<AppDb>): AppDb {
+  const fallback = createDefaultDb();
+  return {
+    ...fallback,
+    ...input,
+    schemaVersion: 4,
+    users: input.users ?? fallback.users,
+    uploads: input.uploads ?? [],
+    pioneerClaims: input.pioneerClaims ?? [],
+    mtfClaims: input.mtfClaims ?? [],
+    inventoryRows: input.inventoryRows ?? [],
+    priceRows: input.priceRows ?? [],
+    reviewDecisions: input.reviewDecisions ?? [],
+  };
+}
+
+export function restoreLocalBackup(raw: unknown) {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Backup file is not valid JSON');
+  }
+  const backup = raw as Partial<LocalBackupPayload>;
+  if (backup.type !== 'pharmacy_analytics_backup') {
+    throw new Error('Unsupported backup format');
+  }
+  if (backup.formatVersion !== BACKUP_FORMAT_VERSION) {
+    throw new Error('Unsupported backup version');
+  }
+  if (!backup.db || !Array.isArray(backup.uploadFiles)) {
+    throw new Error('Backup payload is missing required fields');
+  }
+
+  const restoredDb = normalizeDb(backup.db as Partial<AppDb>);
+  const filesByStoredName = new Map(
+    backup.uploadFiles.map((file) => [file.storedName, file]),
+  );
+
+  for (const upload of restoredDb.uploads) {
+    if (!filesByStoredName.has(upload.storedName)) {
+      throw new Error(`Backup is missing file content for ${upload.originalName}`);
+    }
+  }
+
+  ensure();
+  for (const entry of fs.readdirSync(uploadsDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    fs.unlinkSync(path.join(uploadsDir, entry.name));
+  }
+
+  for (const uploadFile of backup.uploadFiles) {
+    assertSafeStoredName(uploadFile.storedName);
+    const fileBuffer = Buffer.from(uploadFile.base64 || '', 'base64');
+    fs.writeFileSync(path.join(uploadsDir, uploadFile.storedName), fileBuffer);
+  }
+
+  writeDb(restoredDb);
 }
 
 function norm(value: string | null | undefined) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,13 +2,17 @@ import express from 'express';
 import multer from 'multer';
 import path from 'node:path';
 import fs from 'node:fs';
+import zlib from 'node:zlib';
 import { randomUUID } from 'node:crypto';
-import { addUser, clearDataset, ingestInboxDir, PHARMACIES, pharmacyByCode, readDb, saveUpload, setReviewDecision } from './data';
+import { addUser, buildLocalBackup, clearDataset, ingestInboxDir, PHARMACIES, pharmacyByCode, readDb, restoreLocalBackup, saveUpload, setReviewDecision } from './data';
 import { ingestUpload } from './parser';
 import { getAppState } from './analysis';
 import type { PharmacyCode, ReviewLabel, UploadType } from './types';
 
 const upload = multer({ dest: path.resolve(process.cwd(), 'uploads') });
+const backupTempDir = path.resolve(process.cwd(), 'backup_restore_tmp');
+fs.mkdirSync(backupTempDir, { recursive: true });
+const backupUpload = multer({ dest: backupTempDir, limits: { fileSize: 1024 * 1024 * 1024 } });
 const uploadDir = path.resolve(process.cwd(), 'uploads');
 const inboxNamingExamples = [
   'SEMINOLE_pioneer_claims_01012026to03202026.xlsx',
@@ -138,6 +142,12 @@ function scanInbox() {
   };
 }
 
+function parseBackupFileBuffer(input: Buffer) {
+  const isGzip = input.length > 2 && input[0] === 0x1f && input[1] === 0x8b;
+  const text = isGzip ? zlib.gunzipSync(input).toString('utf8') : input.toString('utf8');
+  return JSON.parse(text);
+}
+
 export function registerRoutes(app: express.Express) {
   app.get('/api/bootstrap', (_req, res) => {
     res.json({
@@ -210,5 +220,38 @@ export function registerRoutes(app: express.Express) {
   app.post('/api/clear', express.json(), (req, res) => {
     clearDataset((req.body?.dataset || 'all') as any);
     res.json({ ok: true });
+  });
+
+  app.get('/api/backup/export', (_req, res) => {
+    try {
+      const backup = buildLocalBackup();
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const fileName = `pharmacy-analytics-backup-${stamp}.json.gz`;
+      const zipped = zlib.gzipSync(JSON.stringify(backup), { level: zlib.constants.Z_BEST_COMPRESSION });
+      res.setHeader('Content-Type', 'application/gzip');
+      res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+      res.status(200).send(zipped);
+    } catch (error: any) {
+      res.status(400).json({ message: error?.message || 'Backup export failed' });
+    }
+  });
+
+  app.post('/api/backup/restore', backupUpload.single('file'), (req, res) => {
+    let tempFile = req.file?.path;
+    try {
+      if (!req.file?.path || !fs.existsSync(req.file.path)) {
+        return res.status(400).json({ message: 'Backup file is required' });
+      }
+      const rawFile = fs.readFileSync(req.file.path);
+      const payload = parseBackupFileBuffer(rawFile);
+      restoreLocalBackup(payload);
+      res.json({ ok: true, state: getAppState() });
+    } catch (error: any) {
+      res.status(400).json({ message: error?.message || 'Restore failed' });
+    } finally {
+      if (tempFile && fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    }
   });
 }


### PR DESCRIPTION
### Motivation

- Provide a way to export and restore the app's local data and uploaded source files so an operator can move or recover a complete local state snapshot.

### Description

- Add `buildLocalBackup` and `restoreLocalBackup` in `server/data.ts` to serialize the DB and include uploaded files as base64 payloads and to validate and restore that payload into `app_data` and the `uploads` folder, with safety checks on file names and format versioning.
- Add `GET /api/backup/export` and `POST /api/backup/restore` in `server/routes.ts` including gzip export via `zlib`, a temporary upload area for restore using `multer`, gzip/JSON parsing, and error handling for missing or invalid backups.
- Add client-side UI and logic in `App.tsx` including `exportLocalBackup`, `restoreLocalBackupFromFile`, a file input bound to `restoreFile`, and buttons to trigger export and restore with user confirmation and messaging.
- Ensure existing upload/ingest behavior is unchanged while restore replaces only local `app_data` and uploaded files and enforces validation of backup contents and stored file names.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbeda2b840832e8626d8526ace3b01)