### PR TITLE
Add local release gate, regression test suite, and inbox parser export

### DIFF
--- a/RELEASE_GATES.md
+++ b/RELEASE_GATES.md
@@ -1,0 +1,28 @@
+# Release Gate Verification (Issue 16)
+
+Run these checks locally before shipping any update:
+
+1. `npm run check`
+2. `npm run test:regression`
+3. `npm run build`
+
+Or run the combined gate:
+
+- `npm run release:gate`
+
+## What the regression suite protects
+
+- **Claim lifecycle safety:** B2 reversals and blank claim type + cancelled claims are excluded from active analytics.
+- **Overwrite safety:** inventory uploads overwrite the selected pharmacy snapshot; RX/340B price uploads overwrite their respective group snapshots.
+- **History + dedupe safety:** Pioneer claims and MTF ingests preserve running history while deduping on stable business keys.
+- **Fixed pharmacy mapping safety:** MV and Monte Vista resolve to the same MONTE_VISTA mapping and color.
+
+## Manual verification checklist (post-gate)
+
+1. Upload one Pioneer file with a mix of active + cancelled/reversed claims and confirm inactive claims are counted in excluded totals, not active KPIs.
+2. Upload inventory twice for the same pharmacy and confirm the second file fully replaces that pharmacy inventory rows.
+3. Upload RX price file twice and confirm only the latest RX rows remain (340B should remain untouched).
+4. Upload an MTF payment file with one matching ICN twice (different payment amount), then confirm there is one updated row, not duplicates.
+5. Confirm Monte Vista analytics appear under the fixed MONTE_VISTA identity when file naming uses either `MV` or `Monte Vista` naming conventions.
+
+These gates are intentionally local-only and preserve current upload/reporting workflows.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test:regression": "tsx --test server/regression.test.ts",
+    "release:gate": "npm run check && npm run test:regression && npm run build"
   },
   "dependencies": {
     "express": "^5.1.0",

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -1,0 +1,296 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import xlsx from 'xlsx';
+
+const sandboxRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rx-regression-'));
+process.chdir(sandboxRoot);
+
+const { ingestUpload } = await import('./parser');
+const { getAppState } = await import('./analysis');
+const { readDb, writeDb, resolvePharmacy } = await import('./data');
+const { parseInboxAssignment } = await import('./routes');
+
+function resetDb() {
+  const current = readDb();
+  writeDb({
+    ...current,
+    uploads: [],
+    pioneerClaims: [],
+    mtfClaims: [],
+    inventoryRows: [],
+    priceRows: [],
+    reviewDecisions: [],
+  });
+}
+
+function writeWorkbook(fileName: string, rows: Array<Record<string, string | number | null>>) {
+  const wb = xlsx.utils.book_new();
+  const ws = xlsx.utils.json_to_sheet(rows);
+  xlsx.utils.book_append_sheet(wb, ws, 'Sheet1');
+  const filePath = path.join(sandboxRoot, fileName);
+  xlsx.writeFile(wb, filePath);
+  return filePath;
+}
+
+test.beforeEach(() => {
+  resetDb();
+});
+
+test('claim lifecycle guardrails exclude inactive claims from active analytics', () => {
+  const pioneerPath = writeWorkbook('pioneer-lifecycle.xlsx', [
+    {
+      RxNumber: '1001',
+      NDC: '00003089421',
+      FillDate: '2026-03-01',
+      Quantity: 30,
+      'Days Supply': 30,
+      PrimaryPayer: 'Caremark',
+      InventoryGroup: 'RX',
+      Store: '4',
+      'Claim Status': 'B1',
+      'Current Transaction Status': 'Completed',
+    },
+    {
+      RxNumber: '1002',
+      NDC: '00003089421',
+      FillDate: '2026-03-01',
+      Quantity: 30,
+      'Days Supply': 30,
+      PrimaryPayer: 'Caremark',
+      InventoryGroup: 'RX',
+      Store: '4',
+      'Claim Status': 'B2',
+      'Current Transaction Status': 'Completed',
+    },
+    {
+      RxNumber: '1003',
+      NDC: '00003089421',
+      FillDate: '2026-03-01',
+      Quantity: 30,
+      'Days Supply': 30,
+      PrimaryPayer: 'Caremark',
+      InventoryGroup: 'RX',
+      Store: '4',
+      'Claim Status': '',
+      'Current Transaction Status': 'Cancelled',
+    },
+  ]);
+
+  ingestUpload(pioneerPath, 'pioneer');
+
+  const state = getAppState();
+  assert.equal(state.kpi.pioneerClaims, 1);
+  assert.equal(state.kpi.inactiveClaimsExcluded, 2);
+});
+
+test('inventory and price uploads fully overwrite their target datasets', () => {
+  const inventoryA = writeWorkbook('inventory-a.xlsx', [
+    { NDC: '11111-1111-11', Name: 'Drug A', 'Inventory Group': 'RX', 'Inventory On Hand': 10, 'Last Cost Paid': 5, 'Stock Size': 10 },
+  ]);
+  const inventoryB = writeWorkbook('inventory-b.xlsx', [
+    { NDC: '22222-2222-22', Name: 'Drug B', 'Inventory Group': 'RX', 'Inventory On Hand': 20, 'Last Cost Paid': 4, 'Stock Size': 20 },
+  ]);
+
+  ingestUpload(inventoryA, 'inventory', 'SEMINOLE');
+  ingestUpload(inventoryB, 'inventory', 'SEMINOLE');
+
+  const priceRxA = writeWorkbook('price-rx-a.xlsx', [
+    { NDC: '11111111111', ProperContractPrice: 8, SellDescription: 'Drug A', GCN: 'GCN1' },
+  ]);
+  const priceRxB = writeWorkbook('price-rx-b.xlsx', [
+    { NDC: '22222222222', ProperContractPrice: 7, SellDescription: 'Drug B', GCN: 'GCN2' },
+  ]);
+
+  ingestUpload(priceRxA, 'price_rx');
+  ingestUpload(priceRxB, 'price_rx');
+
+  const db = readDb();
+  const seminoleInventory = db.inventoryRows.filter((row) => row.pharmacyCode === 'SEMINOLE');
+  assert.equal(seminoleInventory.length, 1);
+  assert.equal(seminoleInventory[0].ndc, '22222222222');
+
+  const rxPrices = db.priceRows.filter((row) => row.inventoryGroup === 'RX');
+  assert.equal(rxPrices.length, 1);
+  assert.equal(rxPrices[0].ndc, '22222222222');
+});
+
+test('pioneer and mtf ingests keep running history with dedupe keys', () => {
+  const pioneerA = writeWorkbook('pioneer-a.xlsx', [
+    {
+      RxNumber: '5001',
+      NDC: '00003089421',
+      FillDate: '2026-03-01',
+      Quantity: 30,
+      'Days Supply': 30,
+      PrimaryPayer: 'Caremark',
+      InventoryGroup: 'RX',
+      Store: '4',
+      'Claim Status': 'B1',
+      'Current Transaction Status': 'Completed',
+      TotalPricePaid: 40,
+    },
+  ]);
+  const pioneerB = writeWorkbook('pioneer-b.xlsx', [
+    {
+      RxNumber: '5001',
+      NDC: '00003089421',
+      FillDate: '2026-03-02',
+      Quantity: 30,
+      'Days Supply': 30,
+      PrimaryPayer: 'Caremark',
+      InventoryGroup: 'RX',
+      Store: '4',
+      'Claim Status': 'B1',
+      'Current Transaction Status': 'Completed',
+      TotalPricePaid: 45,
+    },
+    {
+      RxNumber: '5002',
+      NDC: '00003089321',
+      FillDate: '2026-03-02',
+      Quantity: 30,
+      'Days Supply': 30,
+      PrimaryPayer: 'Caremark',
+      InventoryGroup: 'RX',
+      Store: '4',
+      'Claim Status': 'B1',
+      'Current Transaction Status': 'Completed',
+      TotalPricePaid: 50,
+    },
+  ]);
+
+  ingestUpload(pioneerA, 'pioneer');
+  ingestUpload(pioneerB, 'pioneer');
+
+  const mtfA = writeWorkbook('mtf-a.xlsx', [
+    {
+      'Rx Num': '5001',
+      NDC: '00003089421',
+      ICN: 'A-1',
+      'Payment Amount': 11,
+      'Service Date': '2026-03-01',
+      'Payment Issue Date': '2026-03-05',
+      'Store NPI': '1205540101',
+    },
+  ]);
+  const mtfB = writeWorkbook('mtf-b.xlsx', [
+    {
+      'Rx Num': '5001',
+      NDC: '00003089421',
+      ICN: 'A-1',
+      'Payment Amount': 11,
+      'Service Date': '2026-03-01',
+      'Payment Issue Date': '2026-03-05',
+      'Store NPI': '1205540101',
+    },
+    {
+      'Rx Num': '5002',
+      NDC: '00003089321',
+      ICN: 'A-2',
+      'Payment Amount': 7,
+      'Service Date': '2026-03-02',
+      'Payment Issue Date': '2026-03-06',
+      'Store NPI': '1205540101',
+    },
+  ]);
+
+  ingestUpload(mtfA, 'mtf');
+  ingestUpload(mtfB, 'mtf');
+
+  const db = readDb();
+  assert.equal(db.pioneerClaims.length, 2);
+  const refreshedClaim = db.pioneerClaims.find((row) => row.rxNumber === '5001');
+  assert.equal(refreshedClaim?.totalPricePaid, 45);
+
+  assert.equal(db.mtfClaims.length, 2);
+  const dedupedPayment = db.mtfClaims.find((row) => row.rxNumber === '5001' && row.icn === 'A-1');
+  assert.equal(dedupedPayment?.manufacturerPaymentAmount, 11);
+});
+
+
+
+test('sdra status classification covers key payment edge cases', () => {
+  const pioneerPath = writeWorkbook('pioneer-sdra.xlsx', [
+    { RxNumber: '9001', NDC: '00003089421', FillDate: '2026-03-10', Quantity: 10, 'Days Supply': 30, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9002', NDC: '00003089421', FillDate: '2026-03-10', Quantity: 10, 'Days Supply': 30, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9003', NDC: '00003089421', FillDate: '2026-03-01', Quantity: 10, 'Days Supply': 30, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9004', NDC: '00003089421', FillDate: '2026-03-29', Quantity: 10, 'Days Supply': 30, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9005', NDC: '00003089421', FillDate: '2026-03-10', Quantity: 10, 'Days Supply': 30, PrimaryPayer: 'Med D PDP', InventoryGroup: '340B', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9006', NDC: '00003089421', FillDate: '2026-03-10', Quantity: 10, 'Days Supply': 30, PrimaryPayer: 'Med D PDP', InventoryGroup: '340B', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+  ]);
+
+  const mtfPath = writeWorkbook('mtf-sdra.xlsx', [
+    { 'Rx Num': '9001', NDC: '00003089421', ICN: 'SDRA-1', 'Payment Amount': 16.2, 'Service Date': '2026-03-10', 'Payment Issue Date': '2026-03-12', 'Store NPI': '1205540101' },
+    { 'Rx Num': '9002', NDC: '00003089421', ICN: 'SDRA-2', 'Payment Amount': 5, 'Service Date': '2026-03-10', 'Payment Issue Date': '2026-03-12', 'Store NPI': '1205540101' },
+    { 'Rx Num': '9005', NDC: '00003089421', ICN: 'SDRA-3', 'Payment Amount': 8, 'Service Date': '2026-03-10', 'Payment Issue Date': '2026-03-12', 'Store NPI': '1205540101' },
+    { 'Rx Num': '9006', NDC: '00003089421', ICN: 'SDRA-4', 'Payment Amount': -3, 'Service Date': '2026-03-10', 'Payment Issue Date': '2026-03-12', 'Store NPI': '1205540101' },
+  ]);
+
+  ingestUpload(pioneerPath, 'pioneer');
+  ingestUpload(mtfPath, 'mtf');
+
+  const state = getAppState();
+  const statusByRx = new Map(state.sdraResults.map((row) => [row.claim.rxNumber, row.status]));
+
+  assert.equal(statusByRx.get('9001'), 'RX paid correctly');
+  assert.equal(statusByRx.get('9002'), 'RX not paid correctly');
+  assert.equal(statusByRx.get('9003'), 'RX not paid and should have been');
+  assert.equal(statusByRx.get('9004'), 'Pending payment');
+  assert.equal(statusByRx.get('9005'), '340B paid and should not have been');
+  assert.equal(statusByRx.get('9006'), '340B adjustment posted');
+});
+
+test('day-supply exceptions suppress expected stock-cycle claims but still flag true atypical fills', () => {
+  const inventoryPath = writeWorkbook('inventory-days-supply.xlsx', [
+    { NDC: '55555-5555-55', Name: 'Cycle Drug', 'Inventory Group': 'RX', 'Inventory On Hand': 10, 'Last Cost Paid': 5, 'Stock Size': 5 },
+  ]);
+
+  const pioneerPath = writeWorkbook('pioneer-days-supply.xlsx', [
+    { RxNumber: '9101', NDC: '55555-5555-55', FillDate: '2026-03-10', Quantity: 5, 'Days Supply': 28, PrimaryPayer: 'Caremark', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9102', NDC: '55555-5555-55', FillDate: '2026-03-10', Quantity: 5, 'Days Supply': 30, PrimaryPayer: 'Caremark', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+  ]);
+
+  ingestUpload(inventoryPath, 'inventory', 'SEMINOLE');
+  ingestUpload(pioneerPath, 'pioneer');
+
+  const state = getAppState('SEMINOLE');
+  const groupRow = state.claimsAnalysis.find((row) => row.ndc === '55555555555');
+
+  assert.equal(groupRow?.totalClaims, 2);
+  assert.equal(groupRow?.atypicalDaysSupplyCount, 1);
+});
+
+test('inbox filename parser assigns pharmacy and type for supported naming patterns', () => {
+  assert.deepEqual(parseInboxAssignment('SEMINOLE_pioneer_claims_01012026to03202026.xlsx'), {
+    type: 'pioneer',
+    pharmacyCode: 'SEMINOLE',
+  });
+
+  assert.deepEqual(parseInboxAssignment('MV_mtf_payments.csv'), {
+    type: 'mtf',
+    pharmacyCode: 'MONTE_VISTA',
+  });
+
+  assert.deepEqual(parseInboxAssignment('GLOBAL_price_340b_340b_prices.xlsx'), {
+    type: 'price_340b',
+  });
+
+  assert.deepEqual(parseInboxAssignment('SEMINOLE__pioneer__claims.xlsx'), {
+    type: 'pioneer',
+    pharmacyCode: 'SEMINOLE',
+  });
+
+  assert.equal(parseInboxAssignment('unknown_file_name.xlsx'), null);
+});
+
+test('MV and Monte Vista aliases resolve to the same fixed pharmacy mapping', () => {
+  const byAlias = resolvePharmacy({ pharmacyName: 'MV' });
+  const byName = resolvePharmacy({ pharmacyName: 'Monte Vista' });
+
+  assert.equal(byAlias?.code, 'MONTE_VISTA');
+  assert.equal(byName?.code, 'MONTE_VISTA');
+  assert.equal(byAlias?.color, byName?.color);
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -51,7 +51,7 @@ function detectInboxTypeFromTokens(tokens: string[]): UploadType | null {
   return null;
 }
 
-function parseInboxAssignment(fileName: string): { type: UploadType; pharmacyCode?: PharmacyCode } | null {
+export function parseInboxAssignment(fileName: string): { type: UploadType; pharmacyCode?: PharmacyCode } | null {
   const baseName = path.basename(fileName);
   const legacyMatch = /^(.*?)__(pioneer|mtf_adjustment|mtf|inventory|price_rx|price_340b)__(.+)$/i.exec(baseName);
   if (legacyMatch) {


### PR DESCRIPTION
### Motivation

- Provide a reproducible local release gate to prevent regressions before shipping builds. 
- Add a focused regression suite to protect key business behaviors around claims, inventory/price overwrites, history/dedupe, SDRA classifications, and pharmacy mapping. 
- Ensure the inbox filename parser is usable by the tests and other modules by exporting it.

### Description

- Add `RELEASE_GATES.md` documenting the local pre-release checks and a manual verification checklist. 
- Add a regression test file `server/regression.test.ts` that exercises claim lifecycle exclusions, inventory/price overwrite semantics, Pioneer/MTF dedupe and history, SDRA payment classifications, day-supply exception handling, inbox filename parsing, and MV/Monte Vista mapping. 
- Update `package.json` to add `test:regression` (`tsx --test server/regression.test.ts`) and a combined gate script `release:gate` that runs `check`, `test:regression`, and `build`. 
- Export `parseInboxAssignment` from `server/routes.ts` so it can be used by the regression tests and other consumers.

### Testing

- Ran the release gate locally via `npm run release:gate`, which runs `tsc --noEmit`, the regression suite (`npm run test:regression`), and `vite build`, and all steps completed successfully. 
- The regression tests executed the following cases and passed: `claim lifecycle guardrails exclude inactive claims from active analytics`, `inventory and price uploads fully overwrite their target datasets`, `pioneer and mtf ingests keep running history with dedupe keys`, `sdra status classification covers key payment edge cases`, `day-supply exceptions suppress expected stock-cycle claims but still flag true atypical fills`, `inbox filename parser assigns pharmacy and type for supported naming patterns`, and `MV and Monte Vista aliases resolve to the same fixed pharmacy mapping`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf7b48368832eb6c9fbf2ff171549)