### PR TITLE
Add fixture-based regression test, final verification report, and test script

### DIFF
--- a/FINAL_VERIFICATION_20260331.md
+++ b/FINAL_VERIFICATION_20260331.md
@@ -1,0 +1,62 @@
+# Final Verification Pass — 2026-03-31
+
+## Scope
+- Audited current TypeScript/React source and server ingest/analysis pipeline.
+- Re-verified critical business rules against current code paths.
+- Ran final build/compile/start checks.
+- Added automated fixture-based regression coverage for key ingest and analytics guardrails.
+
+## Build and runtime verification
+- `npm run check` passed (`tsc --noEmit`).
+- `npm run build` passed (Vite production build succeeded).
+- `npm run start` reached local bind (`http://127.0.0.1:5000`) and was stopped by timeout for non-interactive verification.
+- `npm run test:fixtures` passed and now validates dedupe, overwrite, and lifecycle exclusion behavior.
+
+## Verified complete
+
+### 1) Local-only architecture remains intact
+- Server binds specifically to `127.0.0.1`.
+- App data, uploads, and ingest inbox are all local folders under the working directory.
+- No outbound/cloud storage dependencies are introduced in current ingest and persistence paths.
+
+### 2) Critical pharmacy mappings and MV normalization remain intact
+- Fixed pharmacy codes/colors/NPI/NCPDP mapping is still hardcoded.
+- MV aliases resolve to Monte Vista consistently in mapping and inbox assignment logic.
+
+### 3) Pioneer remains the analytics base dataset
+- App state is built from Pioneer claims first, then reconciled/enriched with MTF, inventory, and pricing.
+- Active analytics derive from Pioneer claims with lifecycle filtering.
+
+### 4) Ingest semantics match overwrite/history rules
+- Pioneer and MTF/MTF-adjustment ingest paths use key-based merge (history + dedupe behavior).
+- Inventory uploads overwrite per pharmacy (full replacement for selected store).
+- Price uploads overwrite per inventory group (RX or 340B full replacement).
+- Automated fixture regression test now covers these paths.
+
+### 5) Claim lifecycle/business status rules are implemented
+- B2 and reversal statuses normalize to `reversed`.
+- Blank claim type + cancelled status normalizes to `rejected_on_hold`.
+- Cancelled/rejected/transferred/reversed/other inactive claims are retained in history and excluded from active analytics via `activeClaimsOnly`.
+
+### 6) No-manual-coding workflow still present
+- Browser upload endpoint remains available.
+- Inbox scan endpoint supports filename-driven local drop-folder ingestion without user code edits.
+- Bootstrap API still returns default local login and inbox naming examples to guide operation.
+
+## Remaining gaps / unverified areas
+1. **End-to-end replay with production-sized fixtures is still recommended**
+   - The new fixture regression suite covers critical rules, but broad format variance and very large real files should still be sampled before wide rollout.
+2. **Release branch requested by operations was unavailable in local repo**
+   - `release/final-verification` does not exist locally; verification was performed on existing `work` branch state.
+
+## Regressions found in this pass
+- No direct code regressions were identified from static audit + compile/build/start + fixture regression checks.
+
+## Files changed in this pass
+- `FINAL_VERIFICATION_20260331.md`
+- `tests/fixture-regression.test.ts`
+- `package.json`
+
+## Release recommendation
+- **Recommendation: GO** for local release based on passing build checks and passing automated fixture regression coverage for critical business rules.
+- **Recommended before broad rollout:** run one additional sample pass using current production-format files from each upstream source to validate header variance handling.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test:fixtures": "tsx --test tests/fixture-regression.test.ts"
   },
   "dependencies": {
     "express": "^5.1.0",

--- a/tests/fixture-regression.test.ts
+++ b/tests/fixture-regression.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+function writeCsv(filePath: string, rows: string[][]) {
+  const csv = rows.map((row) => row.map((value) => {
+    const text = String(value ?? '');
+    if (/[",\n]/.test(text)) return `"${text.replace(/"/g, '""')}"`;
+    return text;
+  }).join(',')).join('\n');
+  writeFileSync(filePath, csv, 'utf8');
+}
+
+test('fixture regression coverage: dedupe, overwrite, and lifecycle exclusion', async () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'rx-app-fixture-'));
+  process.chdir(tempRoot);
+  mkdirSync('fixtures', { recursive: true });
+
+  const parserModule = await import('../server/parser.ts');
+  const analysisModule = await import('../server/analysis.ts');
+  const dataModule = await import('../server/data.ts');
+
+  const { ingestUpload } = parserModule;
+  const { getAppState } = analysisModule;
+  const { readDb } = dataModule;
+
+  const pioneerBatchA = path.join(tempRoot, 'fixtures', 'pioneer_a.csv');
+  writeCsv(pioneerBatchA, [
+    ['RxNumber', 'NDC', 'FillDate', 'Quantity', 'InventoryGroup', 'ClaimStatus', 'CurrentTransactionStatus', 'PrimaryPayer'],
+    ['1001', '00003089421', '2026-03-01', '30', 'RX', 'B1', 'Paid', 'Med D PDP'],
+    ['1002', '00006011231', '2026-03-02', '30', 'RX', '', 'Cancelled', 'Med D PDP'],
+  ]);
+
+  const pioneerBatchB = path.join(tempRoot, 'fixtures', 'pioneer_b.csv');
+  writeCsv(pioneerBatchB, [
+    ['RxNumber', 'NDC', 'FillDate', 'Quantity', 'InventoryGroup', 'ClaimStatus', 'CurrentTransactionStatus', 'PrimaryPayer', 'TotalPricePaid'],
+    ['1001', '00003089421', '2026-03-01', '30', 'RX', 'B1', 'Paid', 'Med D PDP', '45.00'],
+    ['1003', '00006027731', '2026-03-03', '30', 'RX', 'B1', 'Paid', 'Med D PDP', '50.00'],
+  ]);
+
+  ingestUpload(pioneerBatchA, 'pioneer', 'SEMINOLE');
+  ingestUpload(pioneerBatchB, 'pioneer', 'SEMINOLE');
+
+  let db = readDb();
+  assert.equal(db.pioneerClaims.length, 3, 'pioneer claims should keep history with dedupe replacement');
+
+  const state = getAppState('SEMINOLE');
+  assert.equal(state.kpi.pioneerClaims, 2, 'active analytics should exclude cancelled/rejected lifecycle claims');
+  assert.equal(state.kpi.inactiveClaimsExcluded, 1, 'inactive claim count should be tracked');
+
+  const mtfA = path.join(tempRoot, 'fixtures', 'mtf_a.csv');
+  writeCsv(mtfA, [
+    ['Rx Num', 'ICN', 'Service Date', 'Payment Issue Date', 'NDC', 'MFR Payment Amount'],
+    ['1001', 'ICN-1001', '2026-03-01', '2026-03-10', '00003089421', '10.00'],
+  ]);
+
+  const mtfB = path.join(tempRoot, 'fixtures', 'mtf_b.csv');
+  writeCsv(mtfB, [
+    ['Rx Num', 'ICN', 'Service Date', 'Payment Issue Date', 'NDC', 'MFR Payment Amount'],
+    ['1001', 'ICN-1001', '2026-03-01', '2026-03-10', '00003089421', '10.00'],
+  ]);
+
+  ingestUpload(mtfA, 'mtf', 'SEMINOLE');
+  ingestUpload(mtfB, 'mtf', 'SEMINOLE');
+
+  db = readDb();
+  assert.equal(db.mtfClaims.length, 1, 'mtf claims should dedupe by source key');
+
+  const inventoryA = path.join(tempRoot, 'fixtures', 'inventory_a.csv');
+  writeCsv(inventoryA, [
+    ['NDC', 'Name', 'Inventory Group', 'Inventory Group On Hand', 'Last Cost Paid'],
+    ['11111111111', 'Drug One', 'RX', '5', '3.00'],
+    ['22222222222', 'Drug Two', '340B', '7', '2.00'],
+  ]);
+
+  const inventoryB = path.join(tempRoot, 'fixtures', 'inventory_b.csv');
+  writeCsv(inventoryB, [
+    ['NDC', 'Name', 'Inventory Group', 'Inventory Group On Hand', 'Last Cost Paid'],
+    ['33333333333', 'Drug Three', 'RX', '9', '4.00'],
+  ]);
+
+  ingestUpload(inventoryA, 'inventory', 'SEMINOLE');
+  ingestUpload(inventoryB, 'inventory', 'SEMINOLE');
+
+  db = readDb();
+  const seminoleInventory = db.inventoryRows.filter((row) => row.pharmacyCode === 'SEMINOLE');
+  assert.equal(seminoleInventory.length, 1, 'inventory ingest should fully overwrite per pharmacy');
+  assert.equal(seminoleInventory[0]?.ndc, '33333333333');
+
+  const rxPriceA = path.join(tempRoot, 'fixtures', 'price_rx_a.csv');
+  writeCsv(rxPriceA, [
+    ['NDC', 'ProperContractPrice', 'SellDescription'],
+    ['44444444444', '1.11', 'Price One'],
+    ['55555555555', '2.22', 'Price Two'],
+  ]);
+
+  const rxPriceB = path.join(tempRoot, 'fixtures', 'price_rx_b.csv');
+  writeCsv(rxPriceB, [
+    ['NDC', 'ProperContractPrice', 'SellDescription'],
+    ['66666666666', '3.33', 'Price Three'],
+  ]);
+
+  ingestUpload(rxPriceA, 'price_rx');
+  ingestUpload(rxPriceB, 'price_rx');
+
+  db = readDb();
+  const rxRows = db.priceRows.filter((row) => row.inventoryGroup === 'RX');
+  assert.equal(rxRows.length, 1, 'rx price ingest should fully overwrite the RX group');
+  assert.equal(rxRows[0]?.ndc, '66666666666');
+});


### PR DESCRIPTION
### Motivation
- Add automated fixture regression coverage to validate dedupe, overwrite, and lifecycle-exclusion behavior across ingest pipelines.
- Record the results of a final verification pass for build/runtime and business-rule checks.
- Provide a simple npm script to run the fixture regression test non-interactively.

### Description
- Added `FINAL_VERIFICATION_20260331.md` documenting scope, verification steps, findings, and release recommendation.
- Introduced `tests/fixture-regression.test.ts`, which writes temporary CSV fixtures, imports `ingestUpload`, `getAppState`, and `readDb` from server modules, and asserts dedupe, overwrite, and lifecycle exclusion semantics.
- Updated `package.json` to add the `test:fixtures` script (`tsx --test tests/fixture-regression.test.ts`) and minor script formatting.
- The test covers Pioneer/MTF ingest dedupe, inventory and price overwrite semantics, and active/inactive claim filtering used by analytics.

### Testing
- Ran `npm run check` which executes `tsc --noEmit` and it passed.
- Ran `npm run build` which executed the Vite production build and it passed.
- Ran `npm run test:fixtures` which executed the new fixture regression test and it passed.
- Attempted `npm run start` which reached the local bind at `http://127.0.0.1:5000` and was stopped by a non-interactive timeout during verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbfc41fdd8832eb97cf94b4c2af051)