### PR TITLE
Restore release gate scripts for final verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test:regression": "tsx --test server/regression.test.ts",
+    "release:gate": "npm run check && npm run test:regression && npm run build"
   },
   "dependencies": {
     "express": "^5.1.0",


### PR DESCRIPTION
### Motivation
- The repository's `RELEASE_GATES.md` documents `npm run test:regression` and `npm run release:gate` but those scripts were missing from `package.json`, preventing the documented final verification workflow from running locally.

### Description
- Added two npm scripts to `package.json`: `test:regression` (runs the existing regression suite) and `release:gate` (runs `check`, `test:regression`, and `build`) so the documented release gate flow works as written.

### Testing
- Verified with `npm run check`, `npm run build`, `npx tsx --test server/regression.test.ts`, and `npm run release:gate`; the typecheck, regression suite, and build completed successfully (the `test:regression` and `release:gate` commands failed before the script additions and succeeded after).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc02c41384832e9af4fd92b7a990cb)