### PR TITLE
Add regression test/release gate, improve Python SQLite detection, and refresh UI styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test:regression": "tsx --test server/regression.test.ts",
+    "release:gate": "npm run check && npm run test:regression && npm run build"
   },
   "dependencies": {
     "express": "^5.1.0",

--- a/server/data.ts
+++ b/server/data.ts
@@ -20,6 +20,7 @@ const APP_STATE_ROW_ID = 1;
 const SQLITE_SCHEMA_VERSION = 6;
 let sqliteCliAvailable: boolean | null = null;
 let pythonSqliteAvailable: boolean | null = null;
+let pythonSqliteCmd: string | null = null;
 const ENTITY_TABLES = [
   { table: 'users', path: 'users' },
   { table: 'uploads', path: 'uploads' },
@@ -80,16 +81,28 @@ function canUsePythonSqlite() {
     'import sqlite3',
     "print('ok')",
   ].join('\n');
-  try {
-    const out = execFileSync('python3', ['-c', probe], { encoding: 'utf8' }).trim();
-    pythonSqliteAvailable = out === 'ok';
-  } catch {
-    pythonSqliteAvailable = false;
+  for (const cmd of ['python3', 'python']) {
+    try {
+      const out = execFileSync(cmd, ['-c', probe], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (out === 'ok') {
+        pythonSqliteCmd = cmd;
+        pythonSqliteAvailable = true;
+        return true;
+      }
+    } catch {
+      // continue checking python command candidates
+    }
   }
+  pythonSqliteCmd = null;
+  pythonSqliteAvailable = false;
   return pythonSqliteAvailable;
 }
 
 function runSqlWithPython(sql: string): string {
+  const pythonCmd = pythonSqliteCmd || 'python3';
   const script = [
     'import sqlite3, sys',
     'db_file = sys.argv[1]',
@@ -107,7 +120,7 @@ function runSqlWithPython(sql: string): string {
     'conn.close()',
     'sys.stdout.write(out)',
   ].join('\n');
-  return execFileSync('python3', ['-c', script, sqliteFile, sql], { encoding: 'utf8' });
+  return execFileSync(pythonCmd, ['-c', script, sqliteFile, sql], { encoding: 'utf8' });
 }
 
 function runSql(sql: string): string {

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,15 @@
 :root {
   color-scheme: light;
   font-family: Inter, Arial, sans-serif;
-  --bg: #eef3f9;
+  --bg: #eaf1f8;
   --surface: #ffffff;
   --surface-muted: #f8fbff;
-  --border: #d9e3f0;
-  --text: #132238;
-  --muted: #5f7086;
-  --shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
-  --shadow-soft: 0 4px 14px rgba(15, 23, 42, 0.05);
+  --border: #d3deec;
+  --text: #102033;
+  --muted: #53657c;
+  --focus: #2563eb;
+  --shadow: 0 16px 34px rgba(15, 23, 42, 0.09);
+  --shadow-soft: 0 6px 18px rgba(15, 23, 42, 0.06);
 }
 
 * { box-sizing: border-box; }
@@ -24,6 +25,12 @@ body {
 button, input, select { font: inherit; }
 button { transition: 0.18s ease; }
 button:hover { transform: translateY(-1px); }
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--focus) 72%, white);
+  outline-offset: 1px;
+}
 
 .app-shell {
   position: relative;
@@ -52,7 +59,7 @@ button:hover { transform: translateY(-1px); }
 .card {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 22px;
+  border-radius: 18px;
   padding: 18px;
   box-shadow: var(--shadow-soft);
 }
@@ -112,7 +119,8 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
   font-weight: 600;
 }
 .tab.active {
-  box-shadow: inset 0 0 0 1px currentColor;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 45%, white);
+  background: linear-gradient(180deg, #ffffff, #eef5ff);
 }
 
 .message-banner {
@@ -307,13 +315,18 @@ input, select {
   border: 1px solid #cbd5e1;
   background: white;
   width: 100%;
+  box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.03);
 }
 button.primary {
   border: none;
-  background: #132238;
+  background: linear-gradient(180deg, #1c3150, #132238);
   color: white;
   padding: 10px 14px;
   cursor: pointer;
+  box-shadow: 0 6px 14px rgba(19, 34, 56, 0.22);
+}
+button.primary:hover {
+  filter: brightness(1.02);
 }
 button.secondary {
   background: white;
@@ -321,6 +334,7 @@ button.secondary {
   border: 1px solid #cbd5e1;
   padding: 10px 14px;
   cursor: pointer;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
 }
 .global-upload {
   display: flex;
@@ -409,8 +423,11 @@ th, td {
 th {
   position: sticky;
   top: 0;
-  background: #f8fafc;
+  background: #f6f9fc;
   z-index: 1;
+}
+tr:nth-child(even) td {
+  background: #fcfdff;
 }
 .sort-button {
   border: none;
@@ -587,3 +604,7 @@ th {
   background: #fff;
   font-size: 12px;
 }
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: #c8d4e4; border-radius: 999px; }
+::-webkit-scrollbar-track { background: #f1f5f9; }


### PR DESCRIPTION
### Motivation
- Introduce an automated regression test and a release gate to make local release checks reproducible and stricter.
- Make the server SQLite helpers more robust by detecting available local Python interpreters and using the discovered command to run ad-hoc SQL when the `sqlite3` CLI is not present.
- Update the app styling for improved contrast, focus states, shadows, and small UI refinements for a more polished visual design.

### Description
- Added `test:regression` and `release:gate` scripts to `package.json` and kept the TypeScript `check` script as `tsc --noEmit`.
- In `server/data.ts` added `pythonSqliteCmd` detection and now probe both `python3` and `python`, record the working command, and use it in `runSqlWithPython`; also improved `execFileSync` stdio handling during probing.
- Tweaked many variables and rules in `styles.css`, including updated color tokens, focus-visible outlines, adjusted radii and shadows, button gradients/hover, table header/row backgrounds, striped rows, and custom scrollbar styles.

### Testing
- Ran the TypeScript check with `npm run check` (`tsc --noEmit`) and it completed successfully.
- A regression harness script `npm run test:regression` was added but not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc02c41384832e9af4fd92b7a990cb)