### PR TITLE
Fix claims report horizontal scrolling by prioritizing columns

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,6 +48,7 @@ type ColumnDef = {
   type?: 'text' | 'number' | 'currency' | 'percent';
   width?: string;
   render?: (row: any) => any;
+  compactPriority?: 'primary' | 'secondary' | 'optional';
 };
 
 type OverviewMetric = {
@@ -320,17 +321,17 @@ export default function App() {
   ];
 
   const claimsColumns: ColumnDef[] = [
-    { key: 'pharmacyName', label: 'Pharmacy' },
-    { key: 'ndc', label: 'NDC' },
-    { key: 'drugName', label: 'Drug' },
-    { key: 'inventoryGroup', label: 'Group' },
-    { key: 'totalClaims', label: 'Claims', type: 'number' },
-    { key: 'medDClaims', label: 'Med D', type: 'number' },
-    { key: 'avgRecordedRevenuePerRx', label: 'Avg Remit/RX', type: 'currency' },
-    { key: 'estimatedAcquisition', label: 'Estimated Acquisition', type: 'currency' },
-    { key: 'avgGrossProfitPerRx', label: 'Gross Profit/RX', type: 'currency' },
-    { key: 'opportunity', label: 'Opportunity' },
-    { key: 'severity', label: 'Severity' },
+    { key: 'pharmacyName', label: 'Pharmacy', compactPriority: 'optional' },
+    { key: 'ndc', label: 'NDC', compactPriority: 'secondary' },
+    { key: 'drugName', label: 'Drug', compactPriority: 'primary' },
+    { key: 'inventoryGroup', label: 'Group', compactPriority: 'secondary' },
+    { key: 'totalClaims', label: 'Claims', type: 'number', compactPriority: 'primary' },
+    { key: 'medDClaims', label: 'Med D', type: 'number', compactPriority: 'optional' },
+    { key: 'avgRecordedRevenuePerRx', label: 'Avg Remit/RX', type: 'currency', compactPriority: 'optional' },
+    { key: 'estimatedAcquisition', label: 'Est Acquisition', type: 'currency', compactPriority: 'optional' },
+    { key: 'avgGrossProfitPerRx', label: 'Gross Profit/RX', type: 'currency', compactPriority: 'primary' },
+    { key: 'opportunity', label: 'Opportunity', compactPriority: 'primary' },
+    { key: 'severity', label: 'Severity', compactPriority: 'primary' },
   ];
 
   const thirdPartyColumns: ColumnDef[] = [
@@ -705,7 +706,7 @@ export default function App() {
                 { label: 'Brand cash', onClick: () => setReportContext({ section: 'Claims', filterText: 'Recurring brand cash claims', flaggedOnly: false }), kind: 'secondary' },
               ]}
             />
-            <ReportTable title="Claims analysis" description="Opportunities are grouped by pharmacy + NDC + inventory group and always drill to the exact claim rows driving the signal." rows={state.claimsAnalysis} columns={claimsColumns} exportName="claims_analysis" onApplyLabel={saveReviewDecision} renderDetails={(row) => <DetailTable details={row.details} />} externalFilterText={visibleReportContext?.filterText} externalFlaggedOnly={visibleReportContext?.flaggedOnly} />
+            <ReportTable title="Claims analysis" description="Opportunities are grouped by pharmacy + NDC + inventory group and always drill to the exact claim rows driving the signal." rows={state.claimsAnalysis} columns={claimsColumns} exportName="claims_analysis" onApplyLabel={saveReviewDecision} renderDetails={(row) => <DetailTable details={row.details} />} externalFilterText={visibleReportContext?.filterText} externalFlaggedOnly={visibleReportContext?.flaggedOnly} tableVariant="claims" />
           </>
         )}
 
@@ -1086,6 +1087,7 @@ function ReportTable({
   externalFilterText,
   externalFlaggedOnly,
   onApplyLabel,
+  tableVariant = 'default',
 }: {
   title: string;
   description?: string;
@@ -1099,6 +1101,7 @@ function ReportTable({
   externalFilterText?: string;
   externalFlaggedOnly?: boolean;
   onApplyLabel?: (targetKey: string, label: 'flag' | 'do_not_flag' | 'resolved' | null) => Promise<void> | void;
+  tableVariant?: 'default' | 'claims';
 }) {
   const [sortKey, setSortKey] = useState<string>('');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
@@ -1231,14 +1234,14 @@ function ReportTable({
             </div>
           )}
           {groupOpen && (
-          <div className="table-wrap">
+          <div className={`table-wrap ${tableVariant === 'claims' ? 'report-table-claims' : ''}`}>
             <table>
               <thead>
                 <tr>
                   {allowDrilldown && <th style={{ width: 58 }}>Detail</th>}
                   {showLabelColumn && <th style={{ width: 168 }}>Action taken</th>}
                   {columns.map((column) => (
-                    <th key={column.key} style={{ width: column.width }}>
+                    <th key={column.key} style={{ width: column.width }} data-priority={column.compactPriority || 'primary'}>
                       <button className="sort-button" onClick={() => {
                         if (sortKey === column.key) setSortDir((dir) => dir === 'asc' ? 'desc' : 'asc');
                         else { setSortKey(column.key); setSortDir('asc'); }
@@ -1285,7 +1288,7 @@ function ReportTable({
                           </td>
                         )}
                         {columns.map((column) => (
-                          <td key={`${rowId}-${column.key}`}>
+                          <td key={`${rowId}-${column.key}`} data-priority={column.compactPriority || 'primary'}>
                             <Cell value={cellValue(row, column)} type={column.type} />
                           </td>
                         ))}

--- a/styles.css
+++ b/styles.css
@@ -412,6 +412,18 @@ th {
   background: #f8fafc;
   z-index: 1;
 }
+.report-table-claims th,
+.report-table-claims td {
+  white-space: normal;
+  line-height: 1.35;
+}
+.report-table-claims td[data-priority="primary"] {
+  font-weight: 600;
+}
+.report-table-claims td[data-priority="optional"],
+.report-table-claims th[data-priority="optional"] {
+  display: none;
+}
 .sort-button {
   border: none;
   background: transparent;
@@ -483,6 +495,12 @@ th {
   .app { padding: 16px; }
   .executive-kpi-grid,
   .overview-metrics { grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); }
+}
+@media (max-width: 1280px) {
+  .report-table-claims td[data-priority="secondary"],
+  .report-table-claims th[data-priority="secondary"] {
+    display: none;
+  }
 }
 
 .tabs.card {


### PR DESCRIPTION
### Motivation
- Audit found the claims grid was forced to horizontally scroll because global table cells used `white-space: nowrap` and the Claims report renders many columns with long text, pushing content off-screen.  
- The change aims to make key claim fields readable without horizontal scrolling while preserving row-level drilldown and existing filtering/sorting/export behavior.

### Description
- Files changed: `App.tsx` and `styles.css`.  
- Added a `compactPriority` field to `ColumnDef` and updated the `claimsColumns` to mark each column as `primary`, `secondary`, or `optional`, and shortened the `Estimated Acquisition` label to `Est Acquisition`.  
- Added a `tableVariant` prop to `ReportTable` and enabled `tableVariant="claims"` for the Claims analysis table so only this report uses the compact presentation.  
- Emit `data-priority` attributes on header and data cells and added scoped CSS `.report-table-claims` to allow wrapping (`white-space: normal`), emphasize primary cells, hide `optional` columns, and hide `secondary` columns at narrower widths; drilldown rows, filtering, sorting, and CSV export remain unchanged.  
- Remaining risks: optional/secondary columns are visually hidden in compact mode (they remain in the data and in exports), which may confuse users who expect every summary column on-screen; a future toggle to show all columns could be added if needed.

### Testing
- Ran `npm run check` (`tsc --noEmit`) and it succeeded.  
- Ran `npm run build` (`vite build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc13fea400832e8f5711590b9c25f7)