### PR TITLE
Add Electron desktop launcher, packaging config, paths abstraction, docs, and desktop unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ingest_inbox/
 # Prevent server TS/JS drift by blocking committed transpiled JS artifacts
 server/*.js
 server/*.js.map
+
+# Desktop packaging output
+release/

--- a/README.md
+++ b/README.md
@@ -3,19 +3,23 @@
 This package is prepared for local Windows use.
 
 ## Open the app
-1. Extract the zip to a normal folder such as `C:\RX_Analytics`.
-2. Keep the `node-v24.14.0-win-x64` folder in the same folder as `Open Pharmacy Analytics.exe`.
-3. Double-click `Open Pharmacy Analytics.exe`.
-4. The app should open in the default browser at `http://127.0.0.1:5000`.
+1. Download `Pharmacy Analytics.exe` from the latest release package.
+2. Double-click `Pharmacy Analytics.exe`.
+3. The desktop window opens directly (no Command Prompt needed).
 
-## Important
-- This package does not need `npm install`.
-- This package already includes the local dependencies it needs.
-- If Windows blocks the EXE, open Properties and select **Unblock**, then open it again.
+## Local-only behavior
+- The app runs only on `127.0.0.1`.
+- All data stays on the local machine.
+- Uploaded files, persistence, drilldown, and manual clear behavior remain local.
+- No cloud services are required.
 
-## If it does not open
-The launcher will create:
-- `launcher.log`
-- `launcher-server.log`
+## Data location
+Runtime data is stored in the current Windows user profile under:
+- `%APPDATA%\Pharmacy Analytics\local-data`
 
-If startup fails, the launcher opens those logs automatically in Notepad.
+## Build a Windows executable (maintainers)
+```bash
+npm install
+npm run desktop:pack:win
+```
+The executable is generated under `release/`.

--- a/RUN_WINDOWS.txt
+++ b/RUN_WINDOWS.txt
@@ -1,24 +1,12 @@
 WINDOWS OPEN STEPS
 
-Preferred launcher
-1. Extract the zip.
-2. Keep the folder named node-v24.14.0-win-x64 beside Open Pharmacy Analytics.exe.
-3. Double-click Open Pharmacy Analytics.exe.
-4. Browser should open to http://127.0.0.1:5000
-
-Direct open bypass if the launcher is blocked or closes
-1. Open the extracted app folder.
-2. Click the address bar, type cmd, and press Enter.
-3. Run these commands:
-
-cd /d C:\RX_Analytics
-set "PATH=%CD%\node-v24.14.0-win-x64;%PATH%"
-"%CD%\node-v24.14.0-win-x64\node.exe" "%CD%\node_modules\tsx\dist\cli.mjs" "%CD%\server\index.ts" --production
-
-4. Leave that Command Prompt window open.
-5. Open http://127.0.0.1:5000 in the browser.
+Standard use
+1. Extract the release zip.
+2. Double-click `Pharmacy Analytics.exe`.
+3. The app opens in its own window.
 
 Notes
-- This package does not require npm install.
-- The app now serves the current source directly, so it does not depend on a rebuilt dist folder.
-- If the launcher fails, launcher.log and launcher-server.log should be created.
+- No Command Prompt steps are required for normal use.
+- No npm install is required for end users.
+- The app stays local-only (127.0.0.1 loopback).
+- Data persists in `%APPDATA%\Pharmacy Analytics\local-data`.

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,0 +1,116 @@
+const { app, BrowserWindow, dialog, shell } = require('electron');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const HOST = '127.0.0.1';
+const PORT = Number(process.env.PORT || 5000);
+const APP_URL = `http://${HOST}:${PORT}`;
+const BOOTSTRAP_URL = `${APP_URL}/api/bootstrap`;
+
+let serverProcess = null;
+let mainWindow = null;
+
+function getAppRoot() {
+  if (app.isPackaged) {
+    return process.resourcesPath;
+  }
+  return path.resolve(__dirname, '..');
+}
+
+function getDataRoot() {
+  return path.join(app.getPath('userData'), 'local-data');
+}
+
+function getTsxCliPath(appRoot) {
+  return path.join(appRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+}
+
+function getServerEntryPath(appRoot) {
+  return path.join(appRoot, 'server', 'index.ts');
+}
+
+function startServer() {
+  const appRoot = getAppRoot();
+  const tsxCli = getTsxCliPath(appRoot);
+  const serverEntry = getServerEntryPath(appRoot);
+
+  serverProcess = spawn(process.execPath, [tsxCli, serverEntry, '--production'], {
+    cwd: appRoot,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      USE_DIST: '1',
+      PORT: String(PORT),
+      RX_APP_ROOT: appRoot,
+      RX_APP_DATA_ROOT: getDataRoot(),
+    },
+    windowsHide: true,
+  });
+
+  serverProcess.on('exit', (code) => {
+    if (code !== 0) {
+      dialog.showErrorBox(
+        'Pharmacy Analytics failed to start',
+        'The local analytics server exited unexpectedly. Please reopen the app.'
+      );
+    }
+  });
+}
+
+async function waitForServer(timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(BOOTSTRAP_URL);
+      if (response.ok) return;
+    } catch (_error) {
+      // ignore until timeout
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error('Timed out waiting for local server startup');
+}
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1360,
+    height: 900,
+    autoHideMenuBar: true,
+    webPreferences: {
+      contextIsolation: true,
+      sandbox: true,
+    },
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+}
+
+async function launch() {
+  startServer();
+  await waitForServer();
+  createWindow();
+  await mainWindow.loadURL(APP_URL);
+}
+
+app.whenReady().then(async () => {
+  try {
+    await launch();
+  } catch (error) {
+    dialog.showErrorBox('Pharmacy Analytics', `Unable to open the local app.\n\n${error.message}`);
+    app.quit();
+  }
+});
+
+app.on('window-all-closed', () => {
+  app.quit();
+});
+
+app.on('before-quit', () => {
+  if (serverProcess && !serverProcess.killed) {
+    serverProcess.kill();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "desktop:dev": "electron .",
+    "desktop:pack:win": "npm run build && electron-builder --win portable",
+    "test:desktop": "node --test test/desktop-main.test.mjs"
   },
   "dependencies": {
     "express": "^5.1.0",
     "multer": "^2.0.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "vite": "^7.1.3",
-    "wouter": "^3.3.5",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "tsx": "^4.20.5"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
@@ -25,7 +25,36 @@
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^5.0.0",
-    "tsx": "^4.20.5",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "electron": "^36.0.0",
+    "electron-builder": "^26.0.12",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "vite": "^7.1.3",
+    "wouter": "^3.3.5"
+  },
+  "main": "desktop/main.cjs",
+  "build": {
+    "appId": "com.local.pharmacy.analytics",
+    "productName": "Pharmacy Analytics",
+    "files": [
+      "desktop/**/*",
+      "dist/**/*",
+      "server/**/*",
+      "index.html",
+      "vite.config.ts",
+      "package.json"
+    ],
+    "extraMetadata": {
+      "main": "desktop/main.cjs"
+    },
+    "directories": {
+      "output": "release"
+    },
+    "win": {
+      "target": [
+        "portable"
+      ]
+    }
   }
 }

--- a/server/data.ts
+++ b/server/data.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import type { AppDb, PharmacyCode, PharmacyConfig, ReviewLabel, UploadRecord, UploadType, UserRecord } from './types';
+import { getAppDataDir } from './paths';
 
 export const PHARMACIES: PharmacyConfig[] = [
   { code: 'KONAWA', name: 'Konawa', color: '#eab308', npi: '1003998980', ncpdp: '3723548', aliases: { storeNumbers: ['1'], names: ['konawa', 'the pharmacy @ cofmc 1', 'the pharmacy @ cofmc 1 - konawa'] } },
@@ -11,9 +12,10 @@ export const PHARMACIES: PharmacyConfig[] = [
   { code: 'SEMINOLE', name: 'Seminole', color: '#16a34a', npi: '1205540101', ncpdp: '3731937', aliases: { storeNumbers: ['4'], names: ['seminole', 'the pharmacy @ cofmc 4', 'the pharmacy @ cofmc 4 - seminole'] } }
 ];
 
-const appDir = path.resolve(process.cwd(), 'app_data');
-const uploadsDir = path.resolve(process.cwd(), 'uploads');
-export const ingestInboxDir = path.resolve(process.cwd(), 'ingest_inbox');
+const storageRoot = getAppDataDir();
+const appDir = path.resolve(storageRoot, 'app_data');
+const uploadsDir = path.resolve(storageRoot, 'uploads');
+export const ingestInboxDir = path.resolve(storageRoot, 'ingest_inbox');
 const sqliteFile = path.join(appDir, 'db.sqlite');
 const legacyJsonFile = path.join(appDir, 'db.json');
 const APP_STATE_ROW_ID = 1;

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,8 +2,8 @@ import express from 'express';
 import fs from 'node:fs/promises';
 import syncFs from 'node:fs';
 import path from 'node:path';
-import { createServer as createViteServer } from 'vite';
 import { registerRoutes } from './routes';
+import { getAppRootDir } from './paths';
 
 const app = express();
 app.use((_req, res, next) => {
@@ -18,15 +18,16 @@ registerRoutes(app);
 const wantsProduction = process.argv.includes('--production') || process.env.NODE_ENV === 'production';
 
 async function mountVite() {
+  const { createServer: createViteServer } = await import('vite');
   const vite = await createViteServer({
-    configFile: path.resolve(process.cwd(), 'vite.config.ts'),
+    configFile: path.resolve(getAppRootDir(), 'vite.config.ts'),
     server: { middlewareMode: true },
     appType: 'custom'
   });
   app.use(vite.middlewares);
   app.use(async (req, res, next) => {
     try {
-      const file = await fs.readFile(path.resolve(process.cwd(), 'index.html'), 'utf8');
+      const file = await fs.readFile(path.resolve(getAppRootDir(), 'index.html'), 'utf8');
       const html = await vite.transformIndexHtml(req.originalUrl, file);
       res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
     } catch (error) {
@@ -36,13 +37,13 @@ async function mountVite() {
 }
 
 async function mountDist() {
-  const dist = path.resolve(process.cwd(), 'dist', 'public');
+  const dist = path.resolve(getAppRootDir(), 'dist', 'public');
   app.use(express.static(dist));
   app.use((_req, res) => res.sendFile(path.join(dist, 'index.html')));
 }
 
 async function start() {
-  const dist = path.resolve(process.cwd(), 'dist', 'public', 'index.html');
+  const dist = path.resolve(getAppRootDir(), 'dist', 'public', 'index.html');
   const useDist = wantsProduction && process.env.USE_DIST === '1' && syncFs.existsSync(dist);
 
   if (useDist) {

--- a/server/paths.ts
+++ b/server/paths.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+
+function resolveFromEnv(key: 'RX_APP_ROOT' | 'RX_APP_DATA_ROOT'): string | null {
+  const raw = process.env[key];
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return trimmed ? path.resolve(trimmed) : null;
+}
+
+export function getAppRootDir() {
+  return resolveFromEnv('RX_APP_ROOT') || process.cwd();
+}
+
+export function getAppDataDir() {
+  return resolveFromEnv('RX_APP_DATA_ROOT') || process.cwd();
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,10 +6,11 @@ import { randomUUID } from 'node:crypto';
 import { addUser, clearDataset, ingestInboxDir, PHARMACIES, pharmacyByCode, readDb, saveUpload, setReviewDecision } from './data';
 import { ingestUpload } from './parser';
 import { getAppState } from './analysis';
+import { getAppDataDir } from './paths';
 import type { PharmacyCode, ReviewLabel, UploadType } from './types';
 
-const upload = multer({ dest: path.resolve(process.cwd(), 'uploads') });
-const uploadDir = path.resolve(process.cwd(), 'uploads');
+const uploadDir = path.resolve(getAppDataDir(), 'uploads');
+const upload = multer({ dest: uploadDir });
 const inboxNamingExamples = [
   'SEMINOLE_pioneer_claims_01012026to03202026.xlsx',
   'SEMINOLE_mtf_payments.csv',

--- a/test/desktop-main.test.mjs
+++ b/test/desktop-main.test.mjs
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const desktopMainPath = path.resolve('desktop/main.cjs');
+const source = fs.readFileSync(desktopMainPath, 'utf8');
+
+test('desktop bootstrap starts local server and loads loopback URL', async () => {
+  let readyCallback = null;
+  const appEvents = new Map();
+  const spawnCalls = [];
+  let loadedURL = '';
+
+  const mockChild = {
+    killed: false,
+    on() {},
+    kill() {
+      this.killed = true;
+    },
+  };
+
+  const BrowserWindow = class {
+    constructor() {
+      this.webContents = { setWindowOpenHandler: () => ({ action: 'deny' }) };
+    }
+    async loadURL(url) {
+      loadedURL = url;
+    }
+  };
+
+  const app = {
+    isPackaged: false,
+    getPath(name) {
+      if (name === 'userData') return '/tmp/rx-user';
+      throw new Error(`unexpected getPath(${name})`);
+    },
+    whenReady() {
+      return {
+        then(cb) {
+          readyCallback = cb;
+        },
+      };
+    },
+    on(event, cb) {
+      appEvents.set(event, cb);
+    },
+    quit() {},
+  };
+
+  const context = vm.createContext({
+    require: (id) => {
+      if (id === 'electron') {
+        return {
+          app,
+          BrowserWindow,
+          dialog: { showErrorBox() {} },
+          shell: { openExternal() {} },
+        };
+      }
+      if (id === 'node:path') return path;
+      if (id === 'node:child_process') {
+        return {
+          spawn: (...args) => {
+            spawnCalls.push(args);
+            return mockChild;
+          },
+        };
+      }
+      throw new Error(`unexpected require: ${id}`);
+    },
+    process: {
+      env: {},
+      execPath: '/usr/bin/node',
+      resourcesPath: '/resources',
+    },
+    fetch: async () => ({ ok: true }),
+    setTimeout,
+    clearTimeout,
+    console,
+    __dirname: path.dirname(desktopMainPath),
+  });
+
+  vm.runInContext(source, context, { filename: desktopMainPath });
+  assert.ok(readyCallback, 'app.whenReady callback should register');
+
+  await readyCallback();
+
+  assert.equal(spawnCalls.length, 1, 'server should be spawned once');
+  const [execPath, args, options] = spawnCalls[0];
+  assert.equal(execPath, '/usr/bin/node');
+  assert.ok(args[0].endsWith(path.join('node_modules', 'tsx', 'dist', 'cli.mjs')));
+  assert.ok(args[1].endsWith(path.join('server', 'index.ts')));
+  assert.deepEqual(Array.from(args.slice(2)), ['--production']);
+  assert.equal(options.env.USE_DIST, '1');
+  assert.equal(options.env.RX_APP_DATA_ROOT, '/tmp/rx-user/local-data');
+  assert.equal(options.env.RX_APP_ROOT, path.resolve(path.dirname(desktopMainPath), '..'));
+  assert.equal(loadedURL, 'http://127.0.0.1:5000');
+
+  const beforeQuit = appEvents.get('before-quit');
+  assert.ok(beforeQuit, 'before-quit handler should register');
+  beforeQuit();
+  assert.equal(mockChild.killed, true, 'server should be killed on app quit');
+});


### PR DESCRIPTION
### Motivation
- Provide a self-contained Windows desktop launcher so end users can run the app without manually invoking Node or `npm`, and keep all runtime data local to the user profile.
- Centralize resolution of application root and data directories so the server works correctly when packaged or run from source.
- Add packaging metadata and ignore rules for the generated desktop `release/` output.

### Description
- Add an Electron launcher at `desktop/main.cjs` that spawns the local server, waits for bootstrap, opens a BrowserWindow on `http://127.0.0.1:5000`, and ensures the server is killed on quit.
- Introduce `server/paths.ts` with `getAppRootDir` and `getAppDataDir`, and update `server/index.ts`, `server/data.ts`, and `server/routes.ts` to use these functions and honor `RX_APP_ROOT` / `RX_APP_DATA_ROOT` environment variables.
- Update `package.json` with desktop-related scripts (`desktop:dev`, `desktop:pack:win`, `test:desktop`), add `electron` and `electron-builder` deps/devDeps, set `main` to `desktop/main.cjs`, and add `build` configuration to output portable Windows executables into `release/`.
- Add `release/` to `.gitignore`, add a unit test `test/desktop-main.test.mjs` that mocks the Electron environment and verifies launcher spawn and shutdown behavior, and refresh documentation in `README.md` and `RUN_WINDOWS.txt` to describe desktop usage and data location.

### Testing
- Ran the desktop bootstrap unit test with `node --test test/desktop-main.test.mjs` (exercising the mocked `desktop/main.cjs`), and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc15cf1740832ea2f23c25b4769354)