### PR TITLE
Add missing release gate npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test:regression": "node --test --import tsx server/regression.test.ts",
+    "release:gate": "npm run check && npm run test:regression && npm run build"
   },
   "dependencies": {
     "express": "^5.1.0",


### PR DESCRIPTION
### Motivation
- Restore the documented local release verification workflow by adding the missing npm scripts so the release gate described in RELEASE_GATES.md can be executed locally.

### Description
- Added `test:regression` (`node --test --import tsx server/regression.test.ts`) and `release:gate` (`npm run check && npm run test:regression && npm run build`) to `package.json`; this is the only file changed.

### Testing
- Ran `npm run check` (TypeScript compile check: OK), `node --test --import tsx server/regression.test.ts` (regression suite: 7/7 tests passing), `npm run build` (Vite production build: OK), and `npm run release:gate` (combined gate: OK); prior to this change the documented `test:regression` and `release:gate` scripts were missing and failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc193b4aec832ebe08363235f7fa0e)