### PR TITLE
Dark theme, auth UX refactor, simplify Python SQLite probe, and add regression/release scripts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -85,16 +85,16 @@ const uploadTypeLabels: Record<UploadType, string> = {
 };
 
 const sectionColorMap: Record<Section, string> = {
-  Dashboard: '#132238',
+  Dashboard: '#1f2937',
   Uploads: '#334155',
-  SDRA: '#7c2d12',
+  SDRA: '#6b7280',
   Claims: '#0f766e',
-  'Third Party': '#4338ca',
-  Inventory: '#0f766e',
-  NDC: '#14532d',
-  '340B': '#991b1b',
-  Staffing: '#1d4ed8',
-  Users: '#475569',
+  'Third Party': '#0b3b66',
+  Inventory: '#1d4d4f',
+  NDC: '#1f5f4a',
+  '340B': '#7f1d1d',
+  Staffing: '#1e40af',
+  Users: '#4b5563',
 };
 
 export default function App() {
@@ -227,6 +227,12 @@ export default function App() {
     setSection(targetSection);
     setReportContext({ section: targetSection, filterText: options?.filterText ?? '', flaggedOnly: options?.flaggedOnly ?? false });
     window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function logout() {
+    setUser(null);
+    setSection('Dashboard');
+    setMessage('Logged out');
   }
 
   const visibleReportContext = reportContext.section === section ? reportContext : undefined;
@@ -431,16 +437,32 @@ export default function App() {
             <div className="subtitle">Finance-forward pharmacy intelligence with row-level drilldown, manual clear controls, and store-level color identity across Konawa, Monte Vista, Arlington, and Seminole.</div>
           </div>
           <div className="header-actions">
-            <select value={selectedPharmacy} onChange={(e) => setSelectedPharmacy(e.target.value)}>
-              <option value="ALL">All pharmacies</option>
-              {bootstrap.pharmacies.map((p) => <option key={p.code} value={p.code}>{p.name}</option>)}
-            </select>
-            <div className="status-chip">
-              {user ? `${user.displayName} (${user.role})` : `Default login: ${bootstrap.defaultLogin.username}/${bootstrap.defaultLogin.password}`}
-            </div>
+            {user && (
+              <select value={selectedPharmacy} onChange={(e) => setSelectedPharmacy(e.target.value)}>
+                <option value="ALL">All pharmacies</option>
+                {bootstrap.pharmacies.map((p) => <option key={p.code} value={p.code}>{p.name}</option>)}
+              </select>
+            )}
+            <div className="status-chip">{user ? `${user.displayName} (${user.role})` : 'Not logged in'}</div>
+            {user && <button className="secondary" type="button" onClick={logout}>Log out</button>}
           </div>
         </header>
 
+        {message && <div className="message-banner card">{message}</div>}
+
+        {!user ? (
+          <div className="card section-card" style={{ maxWidth: 460, margin: '20px auto' }}>
+            <div className="eyebrow">Authentication required</div>
+            <h3>Log in to continue</h3>
+            <p className="section-copy">Enter your assigned local credentials to access the dashboard.</p>
+            <form onSubmit={login} className="form-grid" style={{ marginTop: 14 }}>
+              <input name="username" placeholder="Username" autoComplete="username" />
+              <input name="password" type="password" placeholder="Password" autoComplete="current-password" />
+              <button className="primary" type="submit">Log in</button>
+            </form>
+          </div>
+        ) : (
+          <>
         <div className="tabs card">
           {sections.map((s) => (
             <button key={s} className={`tab ${section === s ? 'active' : ''}`} style={section === s ? { borderColor: sectionColorMap[s], background: `${sectionColorMap[s]}14`, color: sectionColorMap[s] } : undefined} onClick={() => setSection(s)}>
@@ -448,8 +470,6 @@ export default function App() {
             </button>
           ))}
         </div>
-
-        {message && <div className="message-banner card">{message}</div>}
 
         {section === 'Dashboard' && (
           <>
@@ -494,28 +514,16 @@ export default function App() {
                   <ActionQueueCard title="Upload integrity" value={state.uploads.length} hint="Manual clear remains available on every dataset" tone="neutral" onClick={() => openReport('Uploads')} />
                 </div>
               </div>
-              {!user ? (
-                <div className="card section-card">
-                  <div className="eyebrow">Authentication</div>
-                  <h3>Log in</h3>
-                  <form onSubmit={login} className="form-grid" style={{ marginTop: 14 }}>
-                    <input name="username" placeholder="Username" defaultValue="admin" />
-                    <input name="password" type="password" placeholder="Password" defaultValue="admin" />
-                    <button className="primary" type="submit">Log in</button>
-                  </form>
+              <div className="card section-card">
+                <div className="eyebrow">Staffing operating note</div>
+                <h3>4.5-day productivity normalization</h3>
+                <p>Monday through Thursday count as 1.0 operating day and Friday counts as 0.5. RX/day is calculated from total observed claims divided by those weighted operating days, and staffing pressure is derived from that RX/day rate.</p>
+                <div className="micro-metrics">
+                  <MiniMetric label="Weighted operating days in data" value={staffingSummary.totalWeightedOperatingDays} />
+                  <MiniMetric label="RX / day" value={staffingSummary.overallAvgRxPerWeightedDay} />
+                  <MiniMetric label="Open / exposed FTE" value={staffingSummary.totalOpenFte} />
                 </div>
-              ) : (
-                <div className="card section-card">
-                  <div className="eyebrow">Staffing operating note</div>
-                  <h3>4.5-day productivity normalization</h3>
-                  <p>Monday through Thursday count as 1.0 operating day and Friday counts as 0.5. RX/day is calculated from total observed claims divided by those weighted operating days, and staffing pressure is derived from that RX/day rate.</p>
-                  <div className="micro-metrics">
-                    <MiniMetric label="Weighted operating days in data" value={staffingSummary.totalWeightedOperatingDays} />
-                    <MiniMetric label="RX / day" value={staffingSummary.overallAvgRxPerWeightedDay} />
-                    <MiniMetric label="Open / exposed FTE" value={staffingSummary.totalOpenFte} />
-                  </div>
-                </div>
-              )}
+              </div>
             </div>
 
             <div className="grid pharmacy-card-grid" style={{ marginTop: 18 }}>
@@ -881,6 +889,8 @@ export default function App() {
               </div>
               <ReportTable title="Current users" description="Local users stay inside the app_data database and can be refreshed or backed up with the rest of the application data." rows={state.users} columns={userColumns} exportName="users" groupByPharmacy={false} allowDrilldown={false} />
             </div>
+          </>
+        )}
           </>
         )}
       </div>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "npm run build && npm run start",
     "build": "vite build",
     "start": "tsx server/index.ts --production",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test:regression": "node --test --import tsx server/regression.test.ts",
+    "release:gate": "npm run check && npm run test:regression && npm run build"
   },
   "dependencies": {
     "express": "^5.1.0",

--- a/server/data.ts
+++ b/server/data.ts
@@ -76,13 +76,9 @@ function canUseSqliteCli() {
 
 function canUsePythonSqlite() {
   if (pythonSqliteAvailable != null) return pythonSqliteAvailable;
-  const probe = [
-    'import sqlite3',
-    "print('ok')",
-  ].join('\n');
   try {
-    const out = execFileSync('python3', ['-c', probe], { encoding: 'utf8' }).trim();
-    pythonSqliteAvailable = out === 'ok';
+    execFileSync('python3', ['-c', 'import sqlite3'], { stdio: 'ignore' });
+    pythonSqliteAvailable = true;
   } catch {
     pythonSqliteAvailable = false;
   }

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,14 @@
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-family: Inter, Arial, sans-serif;
-  --bg: #eef3f9;
-  --surface: #ffffff;
-  --surface-muted: #f8fbff;
-  --border: #d9e3f0;
-  --text: #132238;
-  --muted: #5f7086;
-  --shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
-  --shadow-soft: 0 4px 14px rgba(15, 23, 42, 0.05);
+  --bg: #0b1220;
+  --surface: #111a2b;
+  --surface-muted: #0f1726;
+  --border: #243247;
+  --text: #e6edf7;
+  --muted: #93a4bd;
+  --shadow: 0 12px 28px rgba(0, 0, 0, 0.38);
+  --shadow-soft: 0 4px 14px rgba(0, 0, 0, 0.24);
 }
 
 * { box-sizing: border-box; }
@@ -16,9 +16,9 @@ html, body, #root { min-height: 100%; }
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 28%),
-    radial-gradient(circle at top right, rgba(34, 197, 94, 0.08), transparent 24%),
-    linear-gradient(180deg, #f8fbff 0%, var(--bg) 100%);
+    radial-gradient(circle at top left, rgba(30, 64, 175, 0.22), transparent 30%),
+    radial-gradient(circle at top right, rgba(8, 145, 178, 0.16), transparent 26%),
+    linear-gradient(180deg, #0a1020 0%, var(--bg) 100%);
   color: var(--text);
 }
 button, input, select { font: inherit; }
@@ -34,7 +34,7 @@ button:hover { transform: translateY(-1px); }
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(180deg, rgba(255,255,255,0.65), rgba(255,255,255,0));
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.08), rgba(15, 23, 42, 0));
 }
 
 .app {
@@ -59,7 +59,7 @@ button:hover { transform: translateY(-1px); }
 
 .glass-card {
   backdrop-filter: blur(8px);
-  background: rgba(255, 255, 255, 0.88);
+  background: rgba(17, 26, 43, 0.88);
 }
 
 .topbar {
@@ -81,7 +81,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
   letter-spacing: 0.08em;
   font-size: 11px;
   font-weight: 700;
-  color: #5c6f88;
+  color: #9fb0c8;
 }
 .small, .muted { color: var(--muted); font-size: 13px; }
 .header-actions { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; justify-content: flex-end; }
@@ -92,7 +92,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
   padding: 10px 14px;
   border-radius: 999px;
   border: 1px solid var(--border);
-  background: #f8fbff;
+  background: #0f1726;
   color: var(--text);
 }
 
@@ -104,7 +104,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 }
 .tab {
   border: 1px solid var(--border);
-  background: #fff;
+  background: #101a2b;
   color: var(--text);
   padding: 10px 15px;
   border-radius: 999px;
@@ -117,8 +117,8 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 
 .message-banner {
   margin-bottom: 16px;
-  border-color: #bfdbfe;
-  background: #eff6ff;
+  border-color: #1d4ed8;
+  background: #0f1e3a;
 }
 
 .hero-card {
@@ -126,8 +126,8 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
   grid-template-columns: 1.15fr .85fr;
   gap: 22px;
   background:
-    linear-gradient(135deg, rgba(19, 34, 56, 0.98), rgba(34, 57, 94, 0.95)),
-    linear-gradient(135deg, rgba(37, 99, 235, 0.2), rgba(22, 163, 74, 0.15));
+    linear-gradient(135deg, rgba(31, 41, 55, 0.98), rgba(51, 65, 85, 0.95)),
+    linear-gradient(135deg, rgba(71, 85, 105, 0.2), rgba(100, 116, 139, 0.15));
   color: white;
   border: none;
   box-shadow: var(--shadow);
@@ -159,7 +159,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
   position: relative;
   overflow: hidden;
   min-height: 126px;
-  background: linear-gradient(180deg, #fff, #f8fbff);
+  background: linear-gradient(180deg, #111b2d, #0f1726);
 }
 .executive-kpi::after {
   content: '';
@@ -190,7 +190,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 .action-card {
   text-align: left;
   border: 1px solid var(--border);
-  background: linear-gradient(180deg, #fff, #f8fbff);
+  background: linear-gradient(180deg, #111b2d, #0f1726);
   border-radius: 18px;
   padding: 16px;
   cursor: pointer;
@@ -214,7 +214,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 .section-copy { margin: 0; }
 
 .overview-card {
-  --accent: #132238;
+  --accent: #334155;
   position: relative;
   overflow: hidden;
   margin-bottom: 18px;
@@ -248,7 +248,7 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 14px 14px 12px;
-  background: linear-gradient(180deg, #fff, #fbfdff);
+  background: linear-gradient(180deg, #111b2d, #0f1726);
 }
 .overview-metric.tone-good { border-color: rgba(22, 163, 74, 0.22); }
 .overview-metric.tone-warn { border-color: rgba(245, 158, 11, 0.28); }
@@ -266,8 +266,8 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 .pharmacy-performance-card {
   position: relative;
   overflow: hidden;
-  border-color: color-mix(in srgb, var(--pharmacyColor) 34%, white);
-  background: linear-gradient(180deg, #fff, color-mix(in srgb, var(--pharmacyColor) 7%, white));
+  border-color: color-mix(in srgb, var(--pharmacyColor) 52%, #0f1726);
+  background: linear-gradient(180deg, #121c2d, color-mix(in srgb, var(--pharmacyColor) 14%, #0f1726));
 }
 .pharmacy-performance-card::before {
   content: '';
@@ -304,21 +304,22 @@ select,
 }
 input, select {
   padding: 10px 12px;
-  border: 1px solid #cbd5e1;
-  background: white;
+  border: 1px solid var(--border);
+  background: #0f1726;
+  color: var(--text);
   width: 100%;
 }
 button.primary {
   border: none;
-  background: #132238;
+  background: #1d4ed8;
   color: white;
   padding: 10px 14px;
   cursor: pointer;
 }
 button.secondary {
-  background: white;
+  background: #0f1726;
   color: var(--text);
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--border);
   padding: 10px 14px;
   cursor: pointer;
 }
@@ -327,7 +328,7 @@ button.secondary {
   align-items: center;
   padding: 10px 12px;
   border: 1px solid var(--border);
-  background: #f8fbff;
+  background: #0f1726;
 }
 .form-grid {
   display: grid;
@@ -393,15 +394,15 @@ button.secondary {
 .table-wrap {
   overflow: auto;
   max-height: 560px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
   border-radius: 16px;
-  background: white;
+  background: #0f1726;
 }
 .table-wrap table,
 .detail-wrap table { width: 100%; border-collapse: collapse; font-size: 14px; }
 th, td {
   padding: 11px 12px;
-  border-bottom: 1px solid #edf2f7;
+  border-bottom: 1px solid #1f2b3d;
   text-align: left;
   white-space: nowrap;
   vertical-align: top;
@@ -409,7 +410,7 @@ th, td {
 th {
   position: sticky;
   top: 0;
-  background: #f8fafc;
+  background: #121d30;
   z-index: 1;
 }
 .sort-button {
@@ -421,8 +422,8 @@ th {
   font-weight: 700;
   cursor: pointer;
 }
-.row-flagged { background: #fffdf4; }
-.detail-row td { background: #fbfdff; }
+.row-flagged { background: #2a2212; }
+.detail-row td { background: #101a2b; }
 .detail-wrap {
   border: 1px solid var(--border);
   border-radius: 14px;
@@ -431,7 +432,7 @@ th {
 .link-button {
   border: none;
   background: none;
-  color: #2563eb;
+  color: #93c5fd;
   cursor: pointer;
   padding: 0;
 }
@@ -442,14 +443,14 @@ th {
   gap: 6px;
   padding: 5px 10px;
   border-radius: 999px;
-  background: #eaf2ff;
-  color: #1d4ed8;
+  background: #14284c;
+  color: #93c5fd;
   font-size: 12px;
   font-weight: 600;
 }
-.pill.good { background: #ecfdf5; color: #15803d; }
-.pill.warn { background: #fff7ed; color: #c2410c; }
-.pill.bad { background: #fef2f2; color: #b91c1c; }
+.pill.good { background: #113126; color: #86efac; }
+.pill.warn { background: #3a2810; color: #fdba74; }
+.pill.bad { background: #3f1d24; color: #fda4af; }
 
 .mini-metric {
   border: 1px solid rgba(255,255,255,0.14);
@@ -513,7 +514,7 @@ th {
 
 .clickable-metric {
   border: 1px solid var(--border);
-  background: linear-gradient(180deg, #fff, #fbfdff);
+  background: linear-gradient(180deg, #111b2d, #0f1726);
 }
 
 .queue-toolbar {
@@ -540,7 +541,7 @@ th {
 .queue-table th,
 .queue-table td {
   padding: 12px;
-  border-bottom: 1px solid #edf2f7;
+  border-bottom: 1px solid #1f2b3d;
   vertical-align: top;
 }
 
@@ -558,13 +559,13 @@ th {
   padding: 10px;
   border: 1px solid var(--border);
   border-radius: 14px;
-  background: white;
+  background: #0f1726;
   box-shadow: var(--shadow);
 }
 
 .context-menu button {
   border: 1px solid var(--border);
-  background: #fff;
+  background: #111b2d;
   color: var(--text);
   border-radius: 10px;
   padding: 9px 10px;
@@ -583,7 +584,8 @@ th {
   min-width: 138px;
   padding: 6px 8px;
   border-radius: 8px;
-  border: 1px solid #cbd5e1;
-  background: #fff;
+  border: 1px solid var(--border);
+  background: #0f1726;
+  color: var(--text);
   font-size: 12px;
 }


### PR DESCRIPTION
### Motivation
- Move the UI to a dark visual style and harmonize store/section colors for improved visual clarity and brand consistency.
- Replace the in-page default-login exposure with an explicit authentication flow and logout to avoid showing credentials and to centralize login UX.
- Make Python SQLite availability detection more robust and less verbose by simplifying the probe logic used by the server.
- Add automation hooks for running regression tests and enforcing a release gate during CI.

### Description
- Converted the app to a dark theme by updating CSS variables and many component styles in `styles.css` to new dark color tokens and gradients.
- Refactored authentication in `App.tsx` by adding `logout()`, conditionally rendering the pharmacy selector and logout button only when a user is present, replacing the visible default-login text with a `Not logged in` status, and rendering a centered login card when unauthenticated; moved the message banner and adjusted tab/section layout accordingly.
- Adjusted section and pharmacy color mappings in `App.tsx` to match the new theme and improve contrast for tabs and KPI accents.
- Simplified Python SQLite availability check in `server/data.ts` by attempting `execFileSync('python3', ['-c', 'import sqlite3'], { stdio: 'ignore' })` and basing availability on success rather than using a printed probe.
- Added new npm scripts in `package.json`: `test:regression` to run `server/regression.test.ts` and `release:gate` to run `check`, `test:regression`, and `build` as a gated release step, and tweaked `check` formatting.

### Testing
- No automated tests were executed as part of this change.
- The repository now exposes `npm run test:regression` to execute the node-based regression test and `npm run release:gate` to chain `check`, `test:regression`, and `build` for CI enforcement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc193b4aec832ebe08363235f7fa0e)