### PR TITLE
Local first-run auth: require admin setup, remove default credentials, preserve logout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -108,7 +108,7 @@ const sectionColorMap: Record<Section, string> = {
 };
 
 export default function App() {
-  const [bootstrap, setBootstrap] = useState<{pharmacies: Pharmacy[]; inbox?: { folder?: string; examples?: string[] }} | null>(null);
+  const [bootstrap, setBootstrap] = useState<{pharmacies: Pharmacy[]; auth?: { hasUsers?: boolean; requiresSetup?: boolean }; inbox?: { folder?: string; examples?: string[] }} | null>(null);
   const [state, setState] = useState<AppState | null>(null);
   const [section, setSection] = useState<Section>('Dashboard');
   const [user, setUser] = useState<User | null>(null);
@@ -117,6 +117,7 @@ export default function App() {
   const [uploadForm, setUploadForm] = useState<{ type: UploadType; pharmacyCode: string }>({ type: 'pioneer', pharmacyCode: 'SEMINOLE' });
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
   const [userForm, setUserForm] = useState({ username: '', password: '', displayName: '', role: 'viewer' });
+  const [setupForm, setSetupForm] = useState({ username: '', password: '', displayName: '' });
   const [manualStaffEntries, setManualStaffEntries] = useState<ManualStaffEntry[]>([]);
   const [manualStaffForm, setManualStaffForm] = useState({ pharmacyCode: 'SEMINOLE', roleLabel: '', allocated: '1', covered: '0', names: '', notes: '' });
   const [reportContext, setReportContext] = useState<{ section?: Section; filterText?: string; flaggedOnly?: boolean }>({});
@@ -165,6 +166,22 @@ export default function App() {
     setUser(data.user);
     loadState(selectedPharmacy);
     setMessage('Logged in');
+  }
+
+  async function setupAdmin(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/setup-admin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...setupForm, role: 'admin' }),
+    });
+    const data = await res.json();
+    if (!res.ok) return setMessage(data.message || 'Unable to create initial admin');
+    setUser(data.user);
+    setSetupForm({ username: '', password: '', displayName: '' });
+    setMessage('Initial admin account created');
+    setBootstrap((prev) => prev ? ({ ...prev, auth: { hasUsers: true, requiresSetup: false } }) : prev);
+    loadState(selectedPharmacy);
   }
 
   async function handleUpload(e: React.FormEvent) {
@@ -384,6 +401,7 @@ export default function App() {
 
   if (!bootstrap) return <div className="app"><div className="loading-state">Loading…</div></div>;
   if (!user) {
+    const requiresSetup = Boolean(bootstrap?.auth?.requiresSetup);
     return (
       <div className="app-shell">
         <div className="app-bg" />
@@ -401,13 +419,26 @@ export default function App() {
           {message && <div className="message-banner card">{message}</div>}
           <div className="card section-card" style={{ maxWidth: 460, margin: '20px auto' }}>
             <div className="eyebrow">Authentication required</div>
-            <h3>Log in to continue</h3>
-            <p className="section-copy">Enter your assigned local credentials to access the dashboard.</p>
-            <form onSubmit={login} className="form-grid" style={{ marginTop: 14 }}>
-              <input name="username" placeholder="Username" autoComplete="username" />
-              <input name="password" type="password" placeholder="Password" autoComplete="current-password" />
-              <button className="primary" type="submit">Log in</button>
-            </form>
+            <h3>{requiresSetup ? 'Create initial local admin account' : 'Log in to continue'}</h3>
+            <p className="section-copy">
+              {requiresSetup
+                ? 'No credentials are preloaded. Create the first local admin account for this install.'
+                : 'Enter your assigned local credentials to access the dashboard.'}
+            </p>
+            {requiresSetup ? (
+              <form onSubmit={setupAdmin} className="form-grid" style={{ marginTop: 14 }}>
+                <input placeholder="Display name" value={setupForm.displayName} onChange={(e) => setSetupForm({ ...setupForm, displayName: e.target.value })} />
+                <input placeholder="Username" autoComplete="username" value={setupForm.username} onChange={(e) => setSetupForm({ ...setupForm, username: e.target.value })} />
+                <input type="password" placeholder="Password" autoComplete="new-password" value={setupForm.password} onChange={(e) => setSetupForm({ ...setupForm, password: e.target.value })} />
+                <button className="primary" type="submit">Create admin and continue</button>
+              </form>
+            ) : (
+              <form onSubmit={login} className="form-grid" style={{ marginTop: 14 }}>
+                <input name="username" placeholder="Username" autoComplete="username" />
+                <input name="password" type="password" placeholder="Password" autoComplete="current-password" />
+                <button className="primary" type="submit">Log in</button>
+              </form>
+            )}
           </div>
         </div>
       </div>

--- a/server/data.ts
+++ b/server/data.ts
@@ -33,9 +33,7 @@ const ENTITY_TABLES = [
 function createDefaultDb(): AppDb {
   return {
     schemaVersion: SQLITE_SCHEMA_VERSION,
-    users: [
-      { id: randomUUID(), username: 'admin', password: 'admin', role: 'admin', displayName: 'Default Admin' }
-    ],
+    users: [],
     uploads: [],
     pioneerClaims: [],
     mtfClaims: [],
@@ -45,13 +43,21 @@ function createDefaultDb(): AppDb {
   };
 }
 
+function isLegacyDefaultUser(user: UserRecord | null | undefined) {
+  if (!user) return false;
+  return user.username === 'admin' && user.password === 'admin' && user.role === 'admin' && user.displayName === 'Default Admin';
+}
+
 function normalizeDb(input: Partial<AppDb> | null | undefined): AppDb {
   const fallback = createDefaultDb();
+  const inputUsers = Array.isArray(input?.users) ? input?.users : [];
+  const users = inputUsers.filter((user): user is UserRecord => Boolean(user && user.id && user.username && user.password && user.role && user.displayName));
+  const filteredUsers = users.filter((user) => !isLegacyDefaultUser(user));
   return {
     ...fallback,
     ...(input || {}),
     schemaVersion: SQLITE_SCHEMA_VERSION,
-    users: input?.users ?? fallback.users,
+    users: filteredUsers,
     uploads: input?.uploads ?? [],
     pioneerClaims: input?.pioneerClaims ?? [],
     mtfClaims: input?.mtfClaims ?? [],
@@ -685,6 +691,16 @@ export function clearDataset(dataset: UploadType | 'all') {
 
 export function addUser(user: Omit<UserRecord, 'id'>) {
   const db = readDb();
+  if (db.users.some((existing) => existing.username.toLowerCase() === user.username.toLowerCase())) {
+    throw new Error('Username already exists');
+  }
+  db.users.push({ ...user, id: randomUUID() });
+  writeDb(db);
+}
+
+export function addInitialUser(user: Omit<UserRecord, 'id'>) {
+  const db = readDb();
+  if (db.users.length) throw new Error('Initial user already exists');
   db.users.push({ ...user, id: randomUUID() });
   writeDb(db);
 }

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -39,6 +39,11 @@ test.beforeEach(() => {
   resetDb();
 });
 
+test('fresh local database has no preloaded credentials', () => {
+  const db = readDb();
+  assert.equal(db.users.length, 0);
+});
+
 test('claim lifecycle guardrails exclude inactive claims from active analytics', () => {
   const pioneerPath = writeWorkbook('pioneer-lifecycle.xlsx', [
     {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,7 @@ import multer from 'multer';
 import path from 'node:path';
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
-import { addUser, clearDataset, ingestInboxDir, PHARMACIES, pharmacyByCode, readDb, saveUpload, setReviewDecision } from './data';
+import { addInitialUser, addUser, clearDataset, ingestInboxDir, PHARMACIES, pharmacyByCode, readDb, saveUpload, setReviewDecision } from './data';
 import { ingestUpload } from './parser';
 import { getAppState } from './analysis';
 import { getAppDataDir } from './paths';
@@ -141,6 +141,16 @@ function scanInbox() {
 }
 
 export function registerRoutes(app: express.Express) {
+  function sanitizeCredentialText(value: unknown) {
+    return String(value || '').trim();
+  }
+
+  function normalizeRole(value: unknown) {
+    const role = String(value || '').trim().toLowerCase();
+    if (role === 'admin' || role === 'analyst' || role === 'viewer') return role;
+    return null;
+  }
+
   function parseCookies(req: express.Request) {
     const raw = String(req.headers.cookie || '');
     return raw.split(';').reduce<Record<string, string>>((acc, pair) => {
@@ -167,8 +177,13 @@ export function registerRoutes(app: express.Express) {
   }
 
   app.get('/api/bootstrap', (_req, res) => {
+    const hasUsers = readDb().users.length > 0;
     res.json({
       pharmacies: PHARMACIES,
+      auth: {
+        hasUsers,
+        requiresSetup: !hasUsers,
+      },
       inbox: {
         folder: ingestInboxDir,
         examples: inboxNamingExamples,
@@ -182,14 +197,36 @@ export function registerRoutes(app: express.Express) {
   });
 
   app.post('/api/login', (req, res) => {
-    const { username, password } = req.body ?? {};
+    const username = sanitizeCredentialText(req.body?.username);
+    const password = sanitizeCredentialText(req.body?.password);
     const db = readDb();
+    if (!db.users.length) return res.status(403).json({ message: 'No local users exist yet. Create an admin account first.' });
     const user = db.users.find((u) => u.username === username && u.password === password);
     if (!user) return res.status(401).json({ message: 'Invalid username or password' });
     const token = randomUUID();
     sessions.set(token, user.id);
     res.setHeader('Set-Cookie', `rx_session=${encodeURIComponent(token)}; HttpOnly; Path=/; SameSite=Strict`);
     res.json({ user: { id: user.id, username: user.username, role: user.role, displayName: user.displayName } });
+  });
+
+  app.post('/api/setup-admin', express.json(), (req, res) => {
+    const username = sanitizeCredentialText(req.body?.username);
+    const password = sanitizeCredentialText(req.body?.password);
+    const displayName = sanitizeCredentialText(req.body?.displayName);
+    const role = normalizeRole(req.body?.role);
+    if (!username || !password || !displayName || !role) return res.status(400).json({ message: 'All user fields are required' });
+    if (role !== 'admin') return res.status(400).json({ message: 'Initial user must be an admin' });
+    try {
+      addInitialUser({ username, password, displayName, role });
+    } catch (error: any) {
+      return res.status(409).json({ message: error?.message || 'Initial user already exists' });
+    }
+    const created = readDb().users.find((u) => u.username === username && u.password === password);
+    if (!created) return res.status(500).json({ message: 'Failed to create initial user' });
+    const token = randomUUID();
+    sessions.set(token, created.id);
+    res.setHeader('Set-Cookie', `rx_session=${encodeURIComponent(token)}; HttpOnly; Path=/; SameSite=Strict`);
+    res.json({ user: { id: created.id, username: created.username, role: created.role, displayName: created.displayName } });
   });
 
   app.post('/api/logout', (req, res) => {
@@ -200,9 +237,16 @@ export function registerRoutes(app: express.Express) {
   });
 
   app.post('/api/users', requireAuth, express.json(), (req, res) => {
-    const { username, password, role, displayName } = req.body ?? {};
+    const username = sanitizeCredentialText(req.body?.username);
+    const password = sanitizeCredentialText(req.body?.password);
+    const displayName = sanitizeCredentialText(req.body?.displayName);
+    const role = normalizeRole(req.body?.role);
     if (!username || !password || !role || !displayName) return res.status(400).json({ message: 'All user fields are required' });
-    addUser({ username, password, role, displayName });
+    try {
+      addUser({ username, password, role, displayName });
+    } catch (error: any) {
+      return res.status(409).json({ message: error?.message || 'User add failed' });
+    }
     res.json({ ok: true });
   });
 


### PR DESCRIPTION
### Motivation
- Implement a local login gate that enforces no preloaded credentials and requires creating a local admin on first run.  
- Keep authentication fully local-only (no cloud or third-party providers) and preserve existing app behavior after login.  
- Prevent accidental use of legacy seeded credentials (`admin/admin`) while allowing safe user creation and logout.  

### Description
- Removed the seeded default user and added legacy-seed filtering so existing `admin/admin` seeds are excluded during DB normalization.  
- Added a first-run setup endpoint `POST /api/setup-admin` and `addInitialUser` to create the initial admin only when the user table is empty.  
- Frontend now reads bootstrap `auth` flags and shows either a setup form (first run) or the regular login form; added `setupAdmin` handler and preserved the existing `logout` flow.  
- Validation and sanity: sanitized incoming credential fields, prevented duplicate usernames in `addUser`, and returned clear error status/messages for setup/login flows.  
- Files changed: `App.tsx`, `server/routes.ts`, `server/data.ts`, `server/regression.test.ts`.  

### Testing
- Ran type checks with `npm run check` and it completed successfully.  
- Ran regression tests with `npm run test:regression` which passed (8/8 tests), including a new test verifying a fresh DB has no preloaded credentials.  
- Built the client with `npm run build` and the production bundle compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2b8d2ed4832eb0a216c6fded57db)