### PR TITLE
Style: make .row-flagged use gradient with amber left accent and add test

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -449,7 +449,16 @@ th {
   font-weight: 700;
   cursor: pointer;
 }
-.row-flagged { background: #2a2212; }
+.row-flagged {
+  background: linear-gradient(
+    90deg,
+    rgba(245, 158, 11, 0.26) 0,
+    rgba(245, 158, 11, 0.12) 18px,
+    rgba(15, 23, 38, 0.95) 56px,
+    #0f1726 100%
+  );
+  box-shadow: inset 4px 0 0 rgba(251, 191, 36, 0.9);
+}
 .detail-row td { background: #101a2b; }
 .detail-wrap {
   border: 1px solid var(--border);

--- a/test/flagged-row-style.test.mjs
+++ b/test/flagged-row-style.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const cssPath = resolve(process.cwd(), 'styles.css');
+const css = readFileSync(cssPath, 'utf8');
+
+test('row-flagged style uses gradient plus left accent for fast recognition', () => {
+  const match = css.match(/\.row-flagged\s*\{([\s\S]*?)\}/);
+  assert.ok(match, 'Expected .row-flagged CSS rule to exist.');
+
+  const block = match[1];
+  assert.match(block, /background:\s*linear-gradient\(/, 'Expected row-flagged background to use a gradient.');
+  assert.match(block, /box-shadow:\s*inset\s+4px\s+0\s+0\s+rgba\(251,\s*191,\s*36,\s*0\.9\)/, 'Expected row-flagged style to include the amber left accent.');
+});


### PR DESCRIPTION
### Motivation
- Improve visual prominence and fast recognition of flagged rows by replacing the flat background color with a gradient and a prominent left accent.
- Ensure the new visual pattern is maintained through automated checks by adding a unit test that validates the CSS rule.

### Description
- Updated the `.row-flagged` rule in `styles.css` to use a `linear-gradient` background and an `inset` `box-shadow` for an amber left accent.
- Kept surrounding layout rules intact and formatted the CSS block for readability.
- Added `test/flagged-row-style.test.mjs` which parses `styles.css` and asserts the presence of the gradient and the amber left accent `box-shadow`.

### Testing
- Executed the new unit test via `node --test`, which ran `test/flagged-row-style.test.mjs` and passed.
- No other automated tests were modified or failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc87b70de8832e829006442ad5d531)