### PR TITLE
Restore month-by-month view option in header controls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -115,6 +115,7 @@ export default function App() {
   const [user, setUser] = useState<User | null>(null);
   const [selectedPharmacy, setSelectedPharmacy] = useState('ALL');
   const [selectedMonth, setSelectedMonth] = useState('ALL');
+  const [timeView, setTimeView] = useState<'combined' | 'month_by_month'>('combined');
   const [message, setMessage] = useState('');
   const [uploadForm, setUploadForm] = useState<{ type: UploadType; pharmacyCode: string }>({ type: 'pioneer', pharmacyCode: 'SEMINOLE' });
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
@@ -161,6 +162,13 @@ export default function App() {
     if (!user) return;
     loadState(selectedPharmacy);
   }, [selectedPharmacy, selectedMonth, user]);
+
+  useEffect(() => {
+    if (timeView !== 'month_by_month') return;
+    const months = bootstrap?.reportingMonths || [];
+    if (!months.length) return;
+    if (selectedMonth === 'ALL') setSelectedMonth(months[0]);
+  }, [timeView, bootstrap, selectedMonth]);
 
   async function login(e: React.FormEvent) {
     e.preventDefault();
@@ -596,6 +604,17 @@ export default function App() {
 
   const uploadCounts = countBy(state.uploads, (row) => row.type);
   const staffingSummary = state.staffing?.summary || {};
+  const reportingMonths = bootstrap.reportingMonths || [];
+  const selectedMonthIndex = reportingMonths.findIndex((month) => month === selectedMonth);
+
+  function moveMonth(offset: number) {
+    if (!reportingMonths.length || selectedMonth === 'ALL') return;
+    const current = reportingMonths.findIndex((month) => month === selectedMonth);
+    if (current < 0) return;
+    const next = current + offset;
+    if (next < 0 || next >= reportingMonths.length) return;
+    setSelectedMonth(reportingMonths[next]);
+  }
 
   return (
     <div className="app-shell">
@@ -615,10 +634,26 @@ export default function App() {
               </select>
             )}
             {user && (
-              <select value={selectedMonth} onChange={(e) => setSelectedMonth(e.target.value)}>
-                <option value="ALL">All months</option>
-                {(bootstrap.reportingMonths || []).map((month) => <option key={month} value={month}>{month}</option>)}
+              <select value={timeView} onChange={(e) => {
+                const nextView = e.target.value as 'combined' | 'month_by_month';
+                setTimeView(nextView);
+                if (nextView === 'combined') setSelectedMonth('ALL');
+              }}>
+                <option value="combined">Combined view</option>
+                <option value="month_by_month">Month-by-month view</option>
               </select>
+            )}
+            {user && (
+              <select value={selectedMonth} onChange={(e) => setSelectedMonth(e.target.value)}>
+                {timeView === 'combined' && <option value="ALL">All months</option>}
+                {reportingMonths.map((month) => <option key={month} value={month}>{month}</option>)}
+              </select>
+            )}
+            {user && timeView === 'month_by_month' && (
+              <>
+                <button className="secondary" type="button" onClick={() => moveMonth(1)} disabled={selectedMonthIndex < 0 || selectedMonthIndex >= reportingMonths.length - 1}>Older</button>
+                <button className="secondary" type="button" onClick={() => moveMonth(-1)} disabled={selectedMonthIndex <= 0}>Newer</button>
+              </>
             )}
             <div className="status-chip">{user ? `${user.displayName} (${user.role})` : 'Not logged in'}</div>
             {user && <button className="secondary" type="button" onClick={logout}>Log out</button>}


### PR DESCRIPTION
### Motivation
- Restore a month-by-month viewing workflow so users can step through reporting months without changing backend behavior. 
- Audit confirmed backend month support already exists via `reportingMonths` and the `/api/state?month=YYYY-MM` param, so the fix is a UI wiring/UX addition. 
- Implement the smallest, safest change that preserves local-only behavior and existing request/query flows.

### Description
- Added a `timeView` UI state with values `combined` and `month_by_month` and a compact selector in the topbar to switch views. 
- When entering month-by-month mode the app auto-selects the latest reporting month and exposes `Older`/`Newer` buttons to step through months using a new `moveMonth` helper. 
- Adjusted the month dropdown to show `All months` only in combined view while still sourcing months from `bootstrap.reportingMonths`; the change is isolated to `App.tsx` only and validated by manual code inspection. 
- Exact file changed: `App.tsx`.

### Testing
- Ran `npm run check` (TypeScript typecheck) and it failed in this environment due to a missing `@types/node` dependency. 
- Ran `npm run test:regression` and it failed in this environment due to the `tsx` package not being available. 
- Ran `npm run build` and it failed in this environment due to `vite` not being available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc8d1ca4b4832ea29ccf4d157501ad)