### PR TITLE
Add per-column header filters to ReportTable

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1359,6 +1359,7 @@ function ReportTable({
   const [sortKey, setSortKey] = useState<string>('');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
   const [filterText, setFilterText] = useState(externalFilterText || '');
+  const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
   const [flaggedOnly, setFlaggedOnly] = useState(Boolean(externalFlaggedOnly));
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
@@ -1387,14 +1388,23 @@ function ReportTable({
 
   const filtered = useMemo(() => {
     const text = filterText.trim().toLowerCase();
+    const activeColumnFilters = Object.entries(columnFilters).filter(([, value]) => value.trim());
     return rows.filter((row) => {
       if (flaggedOnly && !row.flagged) return false;
+      if (activeColumnFilters.length) {
+        const matchesColumns = activeColumnFilters.every(([columnKey, filterValue]) => {
+          const column = columns.find((item) => item.key === columnKey);
+          if (!column) return true;
+          return normalizeForSearch(cellValue(row, column)).includes(filterValue.trim().toLowerCase());
+        });
+        if (!matchesColumns) return false;
+      }
       if (!text) return true;
       return columns.some((column) => normalizeForSearch(cellValue(row, column)).includes(text))
         || normalizeForSearch(row.manualLabel).includes(text)
         || normalizeForSearch(row.flagReason).includes(text);
     });
-  }, [rows, columns, filterText, flaggedOnly]);
+  }, [rows, columns, filterText, flaggedOnly, columnFilters]);
 
   const sorted = useMemo(() => {
     const list = [...filtered];
@@ -1460,6 +1470,9 @@ function ReportTable({
         </div>
         <div className="report-actions">
           <input value={filterText} onChange={(e) => setFilterText(e.target.value)} placeholder="Filter this report" />
+          {Object.values(columnFilters).some((value) => value.trim()) && (
+            <button className="secondary" onClick={() => setColumnFilters({})}>Clear column filters</button>
+          )}
           <label className="checkbox-row"><input type="checkbox" checked={flaggedOnly} onChange={(e) => setFlaggedOnly(e.target.checked)} /> Flagged only</label>
           <button className="secondary" onClick={() => exportRows(exportName, columns, sorted)}>Export CSV</button>
         </div>
@@ -1501,6 +1514,21 @@ function ReportTable({
                       }}>
                         {column.label}{sortKey === column.key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
                       </button>
+                    </th>
+                  ))}
+                </tr>
+                <tr className="column-filter-row">
+                  {allowDrilldown && <th />}
+                  {showLabelColumn && <th />}
+                  {columns.map((column) => (
+                    <th key={`${column.key}-filter`} style={{ width: column.width }} data-priority={column.compactPriority || 'primary'}>
+                      <input
+                        className="column-filter-input"
+                        value={columnFilters[column.key] || ''}
+                        onChange={(event) => setColumnFilters((prev) => ({ ...prev, [column.key]: event.target.value }))}
+                        placeholder={`Filter ${column.label}`}
+                        aria-label={`Filter ${column.label}`}
+                      />
                     </th>
                   ))}
                 </tr>

--- a/styles.css
+++ b/styles.css
@@ -449,6 +449,19 @@ th {
   font-weight: 700;
   cursor: pointer;
 }
+.column-filter-row th {
+  top: 44px;
+  padding-top: 8px;
+  padding-bottom: 10px;
+  z-index: 1;
+}
+.column-filter-input {
+  min-width: 120px;
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 12px;
+  border-radius: 8px;
+}
 .row-flagged { background: #2a2212; }
 .detail-row td { background: #101a2b; }
 .detail-wrap {


### PR DESCRIPTION
### Motivation
- The app previously offered only a single global text filter plus a "flagged only" toggle in `ReportTable`, which prevents targeted column-level narrowing when investigating grouped reports. 
- The change implements column-level filters under each header so analysts can quickly restrict rows by specific fields while keeping global filter, sorting, drilldown and export intact. 
- The goal was a minimal, safe change that adds targeted filtering UI without rebuilding table logic or changing grouping/sort/export behaviors.

### Description
- Added a `columnFilters` state and integrated per-column substring, case-insensitive matching into the existing `filtered` pipeline so column filters combine with `flaggedOnly` and the global `filterText`. (file: `App.tsx`).
- Inserted a second sticky header row (`tr.column-filter-row`) with compact inputs under each sortable column header and a conditional `Clear column filters` button in the report action bar. (file: `App.tsx`).
- Updated styles for the header filter row and inputs to keep the UI readable and unobtrusive (`.column-filter-row`, `.column-filter-input`). (file: `styles.css`).
- Preserved existing behavior for grouping, sorting, drilldown expansion, action labeling, and CSV export by filtering before sort/group/render; column filtering uses normalized string-based substring matching for all column values.

### Testing
- Ran `tsc --noEmit` via `npm run check`, which failed with `TS2688 Cannot find type definition file for 'node'` because dependencies were not installed in this environment. (failed)
- Attempted `npm install`, which failed with an external registry `403 Forbidden` preventing dependency restoration and blocking full runtime/browser verification. (failed)
- Code changes were committed locally and lint/formatting checks were not run in this environment; no browser UI tests or visual snapshots were possible here. (N/A)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc8f252560832eae0c8bd039d97191)