### PR TITLE
Fix SPA fallback routing to avoid intercepting API requests

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -26,6 +26,7 @@ async function mountVite() {
   });
   app.use(vite.middlewares);
   app.use(async (req, res, next) => {
+    if (req.method !== 'GET' || req.path.startsWith('/api')) return next();
     try {
       const file = await fs.readFile(path.resolve(getAppRootDir(), 'index.html'), 'utf8');
       const html = await vite.transformIndexHtml(req.originalUrl, file);
@@ -39,7 +40,10 @@ async function mountVite() {
 async function mountDist() {
   const dist = path.resolve(getAppRootDir(), 'dist', 'public');
   app.use(express.static(dist));
-  app.use((_req, res) => res.sendFile(path.join(dist, 'index.html')));
+  app.use((req, res, next) => {
+    if (req.method !== 'GET' || req.path.startsWith('/api')) return next();
+    res.sendFile(path.join(dist, 'index.html'));
+  });
 }
 
 async function start() {


### PR DESCRIPTION
### Motivation
- Prevent the SPA fallback from serving `index.html` for API or non-GET requests by ensuring the fallback only applies to non-API `GET` traffic.

### Description
- Add request guards in `server/index.ts` for both Vite middleware (`mountVite`) and production dist fallback (`mountDist`) so the handler returns early when `req.method !== 'GET'` or `req.path.startsWith('/api')`, preserving API routes.

### Testing
- Ran `npm run check` which failed due to missing Node type definitions (`TS2688: Cannot find type definition file for 'node'`).
- Ran `npm run test:regression` which failed because the `tsx` package could not be resolved in this environment. 
- Attempted `npm install` to restore dependencies but it failed with `403 Forbidden` from the npm registry, so automated tests could not be completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc90c5b720832e90b8a45f75ada004)