### PR TITLE
Restrict user management to admin role

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -76,8 +76,8 @@ type OverviewAction = {
   kind?: 'primary' | 'secondary';
 };
 
-const sections = ['Dashboard', 'Uploads', 'SDRA', 'Claims', 'Third Party', 'Inventory', 'NDC', '340B', 'Staffing', 'Users'] as const;
-type Section = (typeof sections)[number];
+const allSections = ['Dashboard', 'Uploads', 'SDRA', 'Claims', 'Third Party', 'Inventory', 'NDC', '340B', 'Staffing', 'Users'] as const;
+type Section = (typeof allSections)[number];
 const pharmacyOrder = ['KONAWA', 'MONTE_VISTA', 'ARLINGTON', 'SEMINOLE'];
 const pharmacyColorMap: Record<string, string> = {
   KONAWA: '#eab308',
@@ -124,6 +124,9 @@ export default function App() {
   const [manualStaffForm, setManualStaffForm] = useState({ pharmacyCode: 'SEMINOLE', roleLabel: '', allocated: '1', covered: '0', names: '', notes: '' });
   const [reportContext, setReportContext] = useState<{ section?: Section; filterText?: string; flaggedOnly?: boolean }>({});
   const isGlobalPriceUpload = uploadForm.type === 'price_rx' || uploadForm.type === 'price_340b';
+  const visibleSections = user?.role === 'admin'
+    ? allSections
+    : allSections.filter((name) => name !== 'Users');
 
   function isGlobalUpload(type: UploadType) {
     return type === 'price_rx' || type === 'price_340b';
@@ -161,6 +164,10 @@ export default function App() {
     if (!user) return;
     loadState(selectedPharmacy);
   }, [selectedPharmacy, selectedMonth, user]);
+
+  useEffect(() => {
+    if (section === 'Users' && user?.role !== 'admin') setSection('Dashboard');
+  }, [section, user]);
 
   async function login(e: React.FormEvent) {
     e.preventDefault();
@@ -629,7 +636,7 @@ export default function App() {
 
         <>
         <div className="tabs card">
-          {sections.map((s) => (
+          {visibleSections.map((s) => (
             <button key={s} className={`tab ${section === s ? 'active' : ''}`} style={section === s ? { borderColor: sectionColorMap[s], background: `${sectionColorMap[s]}14`, color: sectionColorMap[s] } : undefined} onClick={() => setSection(s)}>
               {s}
             </button>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -176,6 +176,12 @@ export function registerRoutes(app: express.Express) {
     next();
   }
 
+  function requireAdmin(req: express.Request, res: express.Response, next: express.NextFunction) {
+    const user = (req as any).user;
+    if (!user || user.role !== 'admin') return res.status(403).json({ message: 'Admin role required' });
+    next();
+  }
+
   app.get('/api/bootstrap', (_req, res) => {
     const hasUsers = readDb().users.length > 0;
     res.json({
@@ -240,7 +246,7 @@ export function registerRoutes(app: express.Express) {
     res.json({ ok: true });
   });
 
-  app.post('/api/users', requireAuth, express.json(), (req, res) => {
+  app.post('/api/users', requireAuth, requireAdmin, express.json(), (req, res) => {
     const username = sanitizeCredentialText(req.body?.username);
     const password = sanitizeCredentialText(req.body?.password);
     const displayName = sanitizeCredentialText(req.body?.displayName);


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from seeing or modifying local user accounts by enforcing role-based UI and API guards.
- Close a security/UX gap where the `Users` tab and `POST /api/users` were accessible without admin authorization.

### Description
- Add a `requireAdmin` middleware in `server/routes.ts` and apply it to `POST /api/users` so only admin sessions can create new users.
- Update the frontend to compute `visibleSections` from `allSections` based on `user?.role` and render that instead of the full list, hiding the `Users` tab for non-admins (`App.tsx`).
- Add a safety redirect effect in `App.tsx` that sends non-admins from the `Users` section back to `Dashboard` if they somehow reach it.
- Modified files: `server/routes.ts` and `App.tsx`.

### Testing
- Ran `npm run check` which failed due to missing Node type definitions error (`Cannot find type definition file for 'node'`).
- Ran `npm run test:regression` which failed because the `tsx` package could not be resolved (`ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'`).
- Attempted `npm ci` to install deps but it was blocked by the environment registry policy (`403 Forbidden` fetching `electron`), so dependency-based validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc918194fc832eb6eb6f5de11724b4)