### PR TITLE
Replace monthly controls with date-range selectors and add independent IRA comparison range

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -114,8 +114,10 @@ export default function App() {
   const [section, setSection] = useState<Section>('Dashboard');
   const [user, setUser] = useState<User | null>(null);
   const [selectedPharmacy, setSelectedPharmacy] = useState('ALL');
-  const [selectedMonth, setSelectedMonth] = useState('ALL');
-  const [timeView, setTimeView] = useState<'combined' | 'month_by_month'>('combined');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [iraStartDate, setIraStartDate] = useState('');
+  const [iraEndDate, setIraEndDate] = useState('');
   const [message, setMessage] = useState('');
   const [uploadForm, setUploadForm] = useState<{ type: UploadType; pharmacyCode: string }>({ type: 'pioneer', pharmacyCode: 'SEMINOLE' });
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
@@ -136,7 +138,10 @@ export default function App() {
   async function loadState(pharmacyCode = selectedPharmacy) {
     const params = new URLSearchParams();
     if (pharmacyCode && pharmacyCode !== 'ALL') params.set('pharmacyCode', pharmacyCode);
-    if (selectedMonth && selectedMonth !== 'ALL') params.set('month', selectedMonth);
+    if (startDate) params.set('startDate', startDate);
+    if (endDate) params.set('endDate', endDate);
+    if (iraStartDate) params.set('iraStartDate', iraStartDate);
+    if (iraEndDate) params.set('iraEndDate', iraEndDate);
     const query = params.toString() ? `?${params.toString()}` : '';
     const res = await fetch(`/api/state${query}`);
     if (res.status === 401) {
@@ -164,7 +169,7 @@ export default function App() {
   useEffect(() => {
     if (!user) return;
     loadState(selectedPharmacy);
-  }, [selectedPharmacy, selectedMonth, user]);
+  }, [selectedPharmacy, startDate, endDate, iraStartDate, iraEndDate, user]);
 
   useEffect(() => {
     if (section === 'Users' && user?.role !== 'admin') setSection('Dashboard');
@@ -604,17 +609,6 @@ export default function App() {
 
   const uploadCounts = countBy(state.uploads, (row) => row.type);
   const staffingSummary = state.staffing?.summary || {};
-  const reportingMonths = bootstrap.reportingMonths || [];
-  const selectedMonthIndex = reportingMonths.findIndex((month) => month === selectedMonth);
-
-  function moveMonth(offset: number) {
-    if (!reportingMonths.length || selectedMonth === 'ALL') return;
-    const current = reportingMonths.findIndex((month) => month === selectedMonth);
-    if (current < 0) return;
-    const next = current + offset;
-    if (next < 0 || next >= reportingMonths.length) return;
-    setSelectedMonth(reportingMonths[next]);
-  }
 
   return (
     <div className="app-shell">
@@ -634,25 +628,17 @@ export default function App() {
               </select>
             )}
             {user && (
-              <select value={timeView} onChange={(e) => {
-                const nextView = e.target.value as 'combined' | 'month_by_month';
-                setTimeView(nextView);
-                if (nextView === 'combined') setSelectedMonth('ALL');
-              }}>
-                <option value="combined">Combined view</option>
-                <option value="month_by_month">Month-by-month view</option>
-              </select>
-            )}
-            {user && (
-              <select value={selectedMonth} onChange={(e) => setSelectedMonth(e.target.value)}>
-                {timeView === 'combined' && <option value="ALL">All months</option>}
-                {reportingMonths.map((month) => <option key={month} value={month}>{month}</option>)}
-              </select>
-            )}
-            {user && timeView === 'month_by_month' && (
               <>
-                <button className="secondary" type="button" onClick={() => moveMonth(1)} disabled={selectedMonthIndex < 0 || selectedMonthIndex >= reportingMonths.length - 1}>Older</button>
-                <button className="secondary" type="button" onClick={() => moveMonth(-1)} disabled={selectedMonthIndex <= 0}>Newer</button>
+                <label className="date-range-control">
+                  <span>Main range</span>
+                  <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} aria-label="Main start date" />
+                  <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} aria-label="Main end date" />
+                </label>
+                <label className="date-range-control">
+                  <span>IRA 2025 comparison range</span>
+                  <input type="date" value={iraStartDate} onChange={(e) => setIraStartDate(e.target.value)} aria-label="IRA comparison start date" />
+                  <input type="date" value={iraEndDate} onChange={(e) => setIraEndDate(e.target.value)} aria-label="IRA comparison end date" />
+                </label>
               </>
             )}
             <div className="status-chip">{user ? `${user.displayName} (${user.role})` : 'Not logged in'}</div>

--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -41,19 +41,30 @@ function claimYear(claim: Pick<PioneerClaim, 'fillDate' | 'claimDate'>) {
   return match ? Number(match[1]) : null;
 }
 
-function yearMonth(value: string | null | undefined) {
-  const match = /^(\d{4}-\d{2})/.exec(String(value || ''));
+function normalizeIsoDate(value: string | null | undefined) {
+  const match = /^(\d{4}-\d{2}-\d{2})/.exec(String(value || ''));
   return match ? match[1] : null;
 }
 
-function claimInMonth(claim: Pick<PioneerClaim, 'fillDate' | 'claimDate'>, month?: string) {
-  if (!month) return true;
-  return yearMonth(claim.fillDate) === month || yearMonth(claim.claimDate) === month;
+function dateWithinRange(date: string | null, startDate?: string, endDate?: string) {
+  if (!date) return false;
+  if (startDate && date < startDate) return false;
+  if (endDate && date > endDate) return false;
+  return true;
 }
 
-function mtfInMonth(claim: Pick<MtfClaim, 'serviceDate' | 'receiptDate'>, month?: string) {
-  if (!month) return true;
-  return yearMonth(claim.serviceDate) === month || yearMonth(claim.receiptDate) === month;
+function claimInDateRange(claim: Pick<PioneerClaim, 'fillDate' | 'claimDate'>, startDate?: string, endDate?: string) {
+  if (!startDate && !endDate) return true;
+  const fillDate = normalizeIsoDate(claim.fillDate);
+  const claimDate = normalizeIsoDate(claim.claimDate);
+  return dateWithinRange(fillDate, startDate, endDate) || dateWithinRange(claimDate, startDate, endDate);
+}
+
+function mtfInDateRange(claim: Pick<MtfClaim, 'serviceDate' | 'receiptDate'>, startDate?: string, endDate?: string) {
+  if (!startDate && !endDate) return true;
+  const serviceDate = normalizeIsoDate(claim.serviceDate);
+  const receiptDate = normalizeIsoDate(claim.receiptDate);
+  return dateWithinRange(serviceDate, startDate, endDate) || dateWithinRange(receiptDate, startDate, endDate);
 }
 
 function cleanNdc(ndc: string | null | undefined) {
@@ -485,16 +496,21 @@ function buildPriceMaps(priceRows: PriceRow[]) {
   return { byGroupExact, byAnyExact, byGroupFamily, weightedFamily };
 }
 
-export function getAppState(pharmacyCode?: PharmacyCode, reportingMonth?: string) {
+export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?: string; endDate?: string; iraStartDate?: string; iraEndDate?: string }) {
   const db = readDb();
+  const startDate = filters?.startDate;
+  const endDate = filters?.endDate;
+  const iraStartDate = filters?.iraStartDate ?? startDate;
+  const iraEndDate = filters?.iraEndDate ?? endDate;
+
   const scopedPioneerClaims = pharmacyCode ? db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacyCode) : db.pioneerClaims;
-  const pioneerClaimsAll = scopedPioneerClaims.filter((row) => claimInMonth(row, reportingMonth));
+  const pioneerClaimsAll = scopedPioneerClaims.filter((row) => claimInDateRange(row, startDate, endDate));
   const pioneerClaims = activeClaimsOnly(pioneerClaimsAll);
   const scopedMtfClaims = pharmacyCode ? db.mtfClaims.filter((row) => row.pharmacyCode === pharmacyCode) : db.mtfClaims;
-  const mtfClaims = scopedMtfClaims.filter((row) => mtfInMonth(row, reportingMonth));
+  const mtfClaims = scopedMtfClaims.filter((row) => mtfInDateRange(row, startDate, endDate));
   const inventoryRows = pharmacyCode ? db.inventoryRows.filter((row) => row.pharmacyCode === pharmacyCode) : db.inventoryRows;
   const priceRows = db.priceRows;
-  const uploads = db.uploads.filter((row) => !reportingMonth || yearMonth(row.uploadedAt) === reportingMonth);
+  const uploads = db.uploads.filter((row) => dateWithinRange(normalizeIsoDate(row.uploadedAt), startDate, endDate));
 
   const priceMaps = buildPriceMaps(priceRows);
   const pendingCutoff = recentWindowCutoff(pioneerClaims);
@@ -517,9 +533,9 @@ export function getAppState(pharmacyCode?: PharmacyCode, reportingMonth?: string
   };
 
   const pharmacyCards = PHARMACIES.map((pharmacy) => {
-    const claims = activeClaimsOnly(db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacy.code && claimInMonth(row, reportingMonth)));
+    const claims = activeClaimsOnly(db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacy.code && claimInDateRange(row, startDate, endDate)));
     const inventory = db.inventoryRows.filter((row) => row.pharmacyCode === pharmacy.code);
-    const mtf = db.mtfClaims.filter((row) => row.pharmacyCode === pharmacy.code && mtfInMonth(row, reportingMonth));
+    const mtf = db.mtfClaims.filter((row) => row.pharmacyCode === pharmacy.code && mtfInDateRange(row, startDate, endDate));
     return {
       ...pharmacy,
       claimCount: claims.length,
@@ -1181,7 +1197,8 @@ export function getAppState(pharmacyCode?: PharmacyCode, reportingMonth?: string
     byPharmacy: financeByPharmacy,
   };
 
-  const iraClaims = pioneerClaims.filter((claim) => claim.payerType === 'Med D' && sdraMap.has(cleanNdc(claim.ndc)));
+  const iraClaims = activeClaimsOnly(scopedPioneerClaims.filter((claim) => claimInDateRange(claim, iraStartDate, iraEndDate)))
+    .filter((claim) => claim.payerType === 'Med D' && sdraMap.has(cleanNdc(claim.ndc)));
   const iraComparisonBase = [2025, 2026].map((year) => {
     const yearClaims = iraClaims.filter((claim) => claimYear(claim) === year);
     const claimPairs = yearClaims

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -323,7 +323,7 @@ test('ira 2025 vs 2026 comparison tracks financial deltas while keeping 2025 out
   assert.match(String(row2025?.note || ''), /excluded from SDRA totals/i);
 });
 
-test('month filtering scopes dashboard and comparison outputs to selected month', () => {
+test('date range filtering scopes dashboard and comparison outputs to selected range', () => {
   const pioneerPath = writeWorkbook('pioneer-month-filter.xlsx', [
     { RxNumber: '9301', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 100, 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
     { RxNumber: '9302', NDC: '00003089421', FillDate: '2026-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 90, 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
@@ -334,8 +334,8 @@ test('month filtering scopes dashboard and comparison outputs to selected month'
   ingestUpload(pricePath, 'price_rx');
   ingestUpload(pioneerPath, 'pioneer');
 
-  const may2025 = getAppState('SEMINOLE', '2025-05');
-  const may2026 = getAppState('SEMINOLE', '2026-05');
+  const may2025 = getAppState('SEMINOLE', { startDate: '2025-05-01', endDate: '2025-05-31' });
+  const may2026 = getAppState('SEMINOLE', { startDate: '2026-05-01', endDate: '2026-05-31' });
 
   assert.equal(may2025.kpi.pioneerClaims, 1);
   assert.equal(may2026.kpi.pioneerClaims, 1);
@@ -343,4 +343,29 @@ test('month filtering scopes dashboard and comparison outputs to selected month'
   assert.equal(may2026.financeSummary.recordedRevenue, 90);
   assert.equal(may2025.iraYearComparison.find((row) => row.year === 2026)?.claimCount, 0);
   assert.equal(may2026.iraYearComparison.find((row) => row.year === 2025)?.claimCount, 0);
+});
+
+
+test('ira comparison supports an independent date range from the main reporting range', () => {
+  const pioneerPath = writeWorkbook('pioneer-ira-date-ranges.xlsx', [
+    { RxNumber: '9401', NDC: '00003089421', FillDate: '2025-06-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 120, 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9402', NDC: '00003089421', FillDate: '2026-06-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 95, 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+  ]);
+  const pricePath = writeWorkbook('price-ira-date-ranges.xlsx', [
+    { NDC: '00003089421', ProperContractPrice: 5, SellDescription: 'IRA Drug', GCN: 'GCN-IRA' },
+  ]);
+
+  ingestUpload(pricePath, 'price_rx');
+  ingestUpload(pioneerPath, 'pioneer');
+
+  const state = getAppState('SEMINOLE', {
+    startDate: '2026-06-01',
+    endDate: '2026-06-30',
+    iraStartDate: '2025-06-01',
+    iraEndDate: '2025-06-30',
+  });
+
+  assert.equal(state.kpi.pioneerClaims, 1);
+  assert.equal(state.iraYearComparison.find((row) => row.year === 2025)?.claimCount, 1);
+  assert.equal(state.iraYearComparison.find((row) => row.year === 2026)?.claimCount, 0);
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -182,6 +182,11 @@ export function registerRoutes(app: express.Express) {
     next();
   }
 
+  function parseIsoDate(value: unknown) {
+    if (typeof value !== 'string') return undefined;
+    return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined;
+  }
+
   app.get('/api/bootstrap', (_req, res) => {
     const hasUsers = readDb().users.length > 0;
     res.json({
@@ -200,10 +205,11 @@ export function registerRoutes(app: express.Express) {
 
   app.get('/api/state', requireAuth, (req, res) => {
     const pharmacyCode = typeof req.query.pharmacyCode === 'string' && req.query.pharmacyCode !== 'ALL' ? req.query.pharmacyCode as PharmacyCode : undefined;
-    const reportingMonth = typeof req.query.month === 'string' && /^\d{4}-(0[1-9]|1[0-2])$/.test(req.query.month)
-      ? req.query.month
-      : undefined;
-    res.json(getAppState(pharmacyCode, reportingMonth));
+    const startDate = parseIsoDate(req.query.startDate);
+    const endDate = parseIsoDate(req.query.endDate);
+    const iraStartDate = parseIsoDate(req.query.iraStartDate);
+    const iraEndDate = parseIsoDate(req.query.iraEndDate);
+    res.json(getAppState(pharmacyCode, { startDate, endDate, iraStartDate, iraEndDate }));
   });
 
   app.post('/api/login', (req, res) => {

--- a/styles.css
+++ b/styles.css
@@ -94,6 +94,8 @@ p { margin: 8px 0 0; color: var(--muted); line-height: 1.55; }
 }
 .small, .muted { color: var(--muted); font-size: 13px; }
 .header-actions { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; justify-content: flex-end; }
+.date-range-control { display: grid; gap: 6px; min-width: 230px; }
+.date-range-control span { font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); }
 .status-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- The app previously used a month-based picker driven by `bootstrap.reportingMonths`, which could be empty/stale at mount and left the month dropdown unpopulated. 
- The IRA 2025 vs 2026 comparison reused the global month filter and therefore could not be scoped independently from main reporting. 
- The change moves to simple ISO date-range inputs to make time filtering predictable, local-only, and independent for the IRA baseline comparison.

### Description
- Replaced the header month controls with two date-range selectors in the UI: a main reporting range (`startDate` / `endDate`) and a separate IRA comparison range (`iraStartDate` / `iraEndDate`).
- Backend route `/api/state` now accepts ISO date query params `startDate`, `endDate`, `iraStartDate`, and `iraEndDate` and passes them as a filter object to analytics via `getAppState`.
- Replaced month-based filters with date-range helpers so Pioneer claims, MTF rows, and uploads are filtered by date-range (`claimInDateRange`, `mtfInDateRange`, `dateWithinRange`, and `normalizeIsoDate`), and IRA comparison uses its own range (falls back to main range when empty).
- Files changed: `App.tsx`, `server/routes.ts`, `server/analysis.ts`, `server/regression.test.ts`, and `styles.css`.
- Remaining risks: runtime verification is incomplete in this environment because dependency installation/test execution was blocked, so visual/interaction regressions and edge-case date parsing should be validated in a local environment before claiming completion.

### Testing
- Ran `npm run check` (TypeScript check) which failed due to missing environment type packages (error: cannot find type definition file for `node`), so full type-check verification could not complete. (failed)
- Attempted `npm install` but installation was blocked by the environment with an HTTP 403 to the npm registry (package `electron`), so dependencies could not be installed. (blocked)
- Ran the regression test runner `npm run test:regression` which failed to execute due to missing runtime helper `tsx` (package not available in environment), so automated tests could not be executed end-to-end here. (failed/blocked)
- Note: unit/regression test cases were updated to exercise date-range filtering and the independent IRA range, and should pass once dependencies are available and tests are run in a developer environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd29a3c3d0832eaccfa4596877c05d)