### PR TITLE
Fix logout/login auth race and harden auth action flow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -121,6 +121,7 @@ export default function App() {
   const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
   const [userForm, setUserForm] = useState({ username: '', password: '', displayName: '', role: 'viewer' });
   const [setupForm, setSetupForm] = useState({ username: '', password: '', displayName: '' });
+  const [authBusy, setAuthBusy] = useState(false);
   const [manualStaffEntries, setManualStaffEntries] = useState<ManualStaffEntry[]>([]);
   const [manualStaffForm, setManualStaffForm] = useState({ pharmacyCode: 'SEMINOLE', roleLabel: '', allocated: '1', covered: '0', names: '', notes: '' });
   const [reportContext, setReportContext] = useState<{ section?: Section; filterText?: string; flaggedOnly?: boolean }>({});
@@ -172,12 +173,22 @@ export default function App() {
 
   async function login(e: React.FormEvent) {
     e.preventDefault();
+    if (authBusy) return;
+    setAuthBusy(true);
     const fd = new FormData(e.target as HTMLFormElement);
-    const res = await fetch('/api/login', { method: 'POST', body: new URLSearchParams(fd as any) });
-    const data = await res.json();
-    if (!res.ok) return setMessage(data.message || 'Login failed');
-    setUser(data.user);
-    setMessage('Logged in');
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        body: new URLSearchParams(fd as any),
+        credentials: 'same-origin',
+      });
+      const data = await res.json();
+      if (!res.ok) return setMessage(data.message || 'Login failed');
+      setUser(data.user);
+      setMessage('Logged in');
+    } finally {
+      setAuthBusy(false);
+    }
   }
 
   async function setupAdmin(e: React.FormEvent) {
@@ -286,12 +297,20 @@ export default function App() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
-  function logout() {
-    fetch('/api/logout', { method: 'POST' }).catch(() => null);
-    setUser(null);
-    setState(null);
-    setSection('Dashboard');
-    setMessage('Logged out');
+  async function logout() {
+    if (authBusy) return;
+    setAuthBusy(true);
+    try {
+      await fetch('/api/logout', { method: 'POST', credentials: 'same-origin' });
+    } catch {
+      // ignore transient network errors, and still clear local auth state
+    } finally {
+      setUser(null);
+      setState(null);
+      setSection('Dashboard');
+      setMessage('Logged out');
+      setAuthBusy(false);
+    }
   }
 
   function addManualStaffEntry(e: React.FormEvent) {
@@ -447,7 +466,7 @@ export default function App() {
               <form onSubmit={login} className="form-grid" style={{ marginTop: 14 }}>
                 <input name="username" placeholder="Username" autoComplete="username" />
                 <input name="password" type="password" placeholder="Password" autoComplete="current-password" />
-                <button className="primary" type="submit">Log in</button>
+                <button className="primary" type="submit" disabled={authBusy}>{authBusy ? 'Working…' : 'Log in'}</button>
               </form>
             )}
           </div>
@@ -656,7 +675,7 @@ export default function App() {
               </>
             )}
             <div className="status-chip">{user ? `${user.displayName} (${user.role})` : 'Not logged in'}</div>
-            {user && <button className="secondary" type="button" onClick={logout}>Log out</button>}
+            {user && <button className="secondary" type="button" onClick={logout} disabled={authBusy}>{authBusy ? 'Working…' : 'Log out'}</button>}
           </div>
         </header>
 


### PR DESCRIPTION
### Motivation
- Fix a race/stale-session issue where a logout request could clear a newly-established login session and leave the login button unresponsive after logging out.

### Description
- Add an `authBusy` state flag to serialize auth actions and prevent overlapping login/logout requests.
- Make `login` and `logout` include `credentials: 'same-origin'` and make `logout` `async`/`await` the `/api/logout` request so backend and frontend session state remain aligned.
- Disable the login/logout buttons during auth operations and show a short busy label (`Working…`) to prevent duplicate clicks and provide immediate UI feedback.

### Testing
- Ran `npm run check`, which failed in this environment due to missing TypeScript type definitions for `node` (expected environment issue).
- Ran `npm run build`, which completed via the repository's offline prebuilt asset fallback because npm registry access is blocked.
- Ran `npm run test:regression`, which failed in this environment due to the missing `tsx` package (expected environment issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2b7c6470832eac414b22a0deef17)