### PR TITLE
Fix claims table scroll/header overlap by preventing header wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -445,8 +445,11 @@ th {
   overflow-wrap: anywhere;
   word-break: break-word;
 }
+.report-table-claims th {
+  white-space: nowrap;
+}
 .report-table-claims .sort-button {
-  white-space: normal;
+  white-space: nowrap;
   text-align: left;
 }
 .report-table-claims td[data-priority="optional"],


### PR DESCRIPTION
### Motivation
- Audit showed the claims report used a single scroll container (`.table-wrap`) with sticky header rows and the header cells were allowed to wrap while the filter row used a fixed sticky offset (`top: 44px`), creating a variable header height that misaligned the sticky filter row and let claim rows appear to scroll above/through the headers; the intent is to stabilize header height so rows always scroll beneath the headers.

### Description
- Small, CSS-only change in `styles.css`: force `.report-table-claims th { white-space: nowrap; }` and `.report-table-claims .sort-button { white-space: nowrap; }` while preserving data-cell wrapping behavior and leaving all table rendering and data logic (drilldown, sorting, filtering, export) unchanged; exact file changed: `styles.css`.

### Testing
- Attempted automated verification with `npm run check && npm run test:regression` but `tsc` failed due to missing local type definitions and `npm install` was blocked by the environment registry policy (`403` on `electron`), so no regression tests completed successfully in this environment; the fix is scoped to CSS and regarded as low risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2c5a5570832eaf8c9bc07d0a880d)