### PR TITLE
Fix inventory Days On Hand summary to average per-drug (not summed)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1345,10 +1345,12 @@ function summarizeGroup(rows: any[], columns: ColumnDef[]) {
   const manualLabels = rows.filter((row) => row.manualLabel).length;
   const numericColumns = columns.filter((column) => column.type === 'currency' || column.type === 'number');
   const highlights = numericColumns.slice(0, 2).map((column) => {
-    const total = rows.reduce((sum, row) => {
-      const value = Number(cellValue(row, column));
-      return Number.isFinite(value) ? sum + value : sum;
-    }, 0);
+    const values = rows.map((row) => Number(cellValue(row, column))).filter((value) => Number.isFinite(value));
+    const total = values.reduce((sum, value) => sum + value, 0);
+    if (column.key === 'daysOnHand') {
+      const average = values.length ? (total / values.length) : 0;
+      return `${column.label}: ${formatCell(Number(average.toFixed(1)), column.type)}`;
+    }
     return `${column.label}: ${formatCell(total, column.type)}`;
   });
   return { flagged, manualLabels, totalRows: rows.length, highlights };


### PR DESCRIPTION
### Motivation
- The inventory group summary was summing numeric columns generically which caused `Days On Hand` to be aggregated across multiple drugs and yield unrealistic totals, while backend per-drug `daysOnHand` is already computed correctly by `server/analysis.ts`.

### Description
- Small UI fix in `App.tsx`: update `summarizeGroup` so `daysOnHand` is shown as the average of visible rows (rounded to 1 decimal) instead of being summed, while keeping summation behavior for other numeric/currency columns and preserving store grouping, drilldown, filtering, sorting, and CSV export; changed file: `App.tsx`.

### Testing
- Automated checks attempted: `npm run check` (TypeScript) failed due to missing `@types/node` in this environment, and `npm ci` failed with registry 403, so no full automated test suite completed; change was validated by code inspection and targeted local edits only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2d28c5b8832eaf917617d4be4703)