### PR TITLE
Exclude 2025 claims from general KPI and revenue totals

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -490,6 +490,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, reportingMonth?: string
   const scopedPioneerClaims = pharmacyCode ? db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacyCode) : db.pioneerClaims;
   const pioneerClaimsAll = scopedPioneerClaims.filter((row) => claimInMonth(row, reportingMonth));
   const pioneerClaims = activeClaimsOnly(pioneerClaimsAll);
+  const generalAnalyticsClaims = pioneerClaims.filter((row) => claimYear(row) !== 2025);
   const scopedMtfClaims = pharmacyCode ? db.mtfClaims.filter((row) => row.pharmacyCode === pharmacyCode) : db.mtfClaims;
   const mtfClaims = scopedMtfClaims.filter((row) => mtfInMonth(row, reportingMonth));
   const inventoryRows = pharmacyCode ? db.inventoryRows.filter((row) => row.pharmacyCode === pharmacyCode) : db.inventoryRows;
@@ -503,13 +504,13 @@ export function getAppState(pharmacyCode?: PharmacyCode, reportingMonth?: string
   const inventoryReferenceMap = buildInventoryReferenceMap(inventoryRows);
 
   const kpi = {
-    pioneerClaims: pioneerClaims.length,
+    pioneerClaims: generalAnalyticsClaims.length,
     inactiveClaimsExcluded: pioneerClaimsAll.length - pioneerClaims.length,
-    medDClaims: pioneerClaims.filter((row) => row.payerType === 'Med D').length,
+    medDClaims: generalAnalyticsClaims.filter((row) => row.payerType === 'Med D').length,
     inventoryItems: inventoryRows.length,
     totalInventoryValue: money(sum(inventoryRows.map((row) => Math.max(row.onHand, 0) * Number(row.lastCostPaid || 0)))),
-    '340bClaims': pioneerClaims.filter((row) => row.inventoryGroup === '340B').length,
-    rxClaims: pioneerClaims.filter((row) => row.inventoryGroup === 'RX').length,
+    '340bClaims': generalAnalyticsClaims.filter((row) => row.inventoryGroup === '340B').length,
+    rxClaims: generalAnalyticsClaims.filter((row) => row.inventoryGroup === 'RX').length,
     uploadedFiles: uploads.length,
     mtfRows: mtfClaims.filter((row) => row.sourceType === 'mtf').length,
     adjustmentRows: mtfClaims.filter((row) => row.sourceType === 'mtf_adjustment').length,
@@ -517,7 +518,8 @@ export function getAppState(pharmacyCode?: PharmacyCode, reportingMonth?: string
   };
 
   const pharmacyCards = PHARMACIES.map((pharmacy) => {
-    const claims = activeClaimsOnly(db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacy.code && claimInMonth(row, reportingMonth)));
+    const claims = activeClaimsOnly(db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacy.code && claimInMonth(row, reportingMonth)))
+      .filter((row) => claimYear(row) !== 2025);
     const inventory = db.inventoryRows.filter((row) => row.pharmacyCode === pharmacy.code);
     const mtf = db.mtfClaims.filter((row) => row.pharmacyCode === pharmacy.code && mtfInMonth(row, reportingMonth));
     return {
@@ -1125,9 +1127,9 @@ export function getAppState(pharmacyCode?: PharmacyCode, reportingMonth?: string
     referralChecks: compliance.filter((row) => /referral verification queue/i.test(row?.finding || '')).length
   };
 
-  const pairedFinancials = pioneerClaims.map((claim) => grossProfitTuple(claim, priceMaps)).filter(Boolean) as { remit:number; acquisition:number; grossProfit:number }[];
+  const pairedFinancials = generalAnalyticsClaims.map((claim) => grossProfitTuple(claim, priceMaps)).filter(Boolean) as { remit:number; acquisition:number; grossProfit:number }[];
   const financeByPharmacy = PHARMACIES.map((pharmacy) => {
-    const claims = pioneerClaims.filter((claim) => claim.pharmacyCode === pharmacy.code);
+    const claims = generalAnalyticsClaims.filter((claim) => claim.pharmacyCode === pharmacy.code);
     const pairs = claims.map((claim) => grossProfitTuple(claim, priceMaps)).filter(Boolean) as { remit:number; acquisition:number; grossProfit:number }[];
     const sdraRows = sdraResults.filter((row) => row.pharmacyCode === pharmacy.code);
     const flaggedActions = sdraRows.filter((row) => row.flagged).length

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -316,6 +316,8 @@ test('ira 2025 vs 2026 comparison tracks financial deltas while keeping 2025 out
   const row2025 = state.iraYearComparison.find((row) => row.year === 2025);
   const row2026 = state.iraYearComparison.find((row) => row.year === 2026);
 
+  assert.equal(state.kpi.pioneerClaims, 1);
+  assert.equal(state.financeSummary.recordedRevenue, 80);
   assert.equal(row2025?.totalRevenue, 100);
   assert.equal(row2026?.totalRevenue, 80);
   assert.equal(row2026?.revenueDeltaVs2025, -20);
@@ -337,10 +339,11 @@ test('month filtering scopes dashboard and comparison outputs to selected month'
   const may2025 = getAppState('SEMINOLE', '2025-05');
   const may2026 = getAppState('SEMINOLE', '2026-05');
 
-  assert.equal(may2025.kpi.pioneerClaims, 1);
+  assert.equal(may2025.kpi.pioneerClaims, 0);
   assert.equal(may2026.kpi.pioneerClaims, 1);
-  assert.equal(may2025.financeSummary.recordedRevenue, 100);
+  assert.equal(may2025.financeSummary.recordedRevenue, 0);
   assert.equal(may2026.financeSummary.recordedRevenue, 90);
+  assert.equal(may2025.iraYearComparison.find((row) => row.year === 2025)?.claimCount, 1);
   assert.equal(may2025.iraYearComparison.find((row) => row.year === 2026)?.claimCount, 0);
   assert.equal(may2026.iraYearComparison.find((row) => row.year === 2025)?.claimCount, 0);
 });


### PR DESCRIPTION
### Motivation
- Audit of `getAppState` showed general KPIs and finance totals were built from the full active Pioneer claim set (`pioneerClaims`), which caused 2025 claims to flow into dashboard KPIs and total revenue.  
- The intent is to exclude 2025 claims from general revenue/KPI calculations while preserving 2025 as the SDRA/IRA baseline where explicitly required.

### Description
- Introduced `generalAnalyticsClaims = pioneerClaims.filter((row) => claimYear(row) !== 2025)` in `server/analysis.ts`.  
- Switched general KPI counters (`kpi.pioneerClaims`, `kpi.medDClaims`, `kpi['340bClaims']`, `kpi.rxClaims`) to use `generalAnalyticsClaims`.  
- Updated pharmacy card and finance calculations so `pharmacyCards` claim counts, `pairedFinancials`, `financeByPharmacy`, and `financeSummary.recordedRevenue` use `generalAnalyticsClaims`, while leaving `iraClaims` (SDRA/IRA comparison) sourced from the full `pioneerClaims` set to preserve 2025 baseline behavior.  
- Updated `server/regression.test.ts` to assert the new behavior for dashboard KPIs and recorded revenue and to preserve IRA comparison expectations for 2025.

### Testing
- Ran TypeScript check with `npm run check`, which failed in this environment due to missing `@types/node` and blocked dependency installation.  
- Ran regression tests with `npm run test:regression`, which failed in this environment due to a missing `tsx` package that cannot be installed here.  
- Verified code changes via static code inspection and committed the changes (`server/analysis.ts`, `server/regression.test.ts`), but full automated test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2e3e5620832e8bf4d1f3a7c96e14)