### PR TITLE
Fix dashboard totals to include newly uploaded claims in selected date range

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -534,7 +534,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   };
 
   const pharmacyCards = PHARMACIES.map((pharmacy) => {
-    const claims = activeClaimsOnly(db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacy.code && claimInMonth(row, reportingMonth)))
+    const claims = activeClaimsOnly(db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacy.code && claimInDateRange(row, startDate, endDate)))
       .filter((row) => claimYear(row) !== 2025);
     const inventory = db.inventoryRows.filter((row) => row.pharmacyCode === pharmacy.code);
     const mtf = db.mtfClaims.filter((row) => row.pharmacyCode === pharmacy.code && mtfInDateRange(row, startDate, endDate));

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -343,6 +343,8 @@ test('date range filtering scopes dashboard and comparison outputs to selected r
   assert.equal(may2026.kpi.pioneerClaims, 1);
   assert.equal(may2025.financeSummary.recordedRevenue, 0);
   assert.equal(may2026.financeSummary.recordedRevenue, 90);
+  assert.equal(may2025.pharmacyCards.find((row) => row.code === 'SEMINOLE')?.claimCount, 0);
+  assert.equal(may2026.pharmacyCards.find((row) => row.code === 'SEMINOLE')?.claimCount, 1);
   assert.equal(may2025.iraYearComparison.find((row) => row.year === 2025)?.claimCount, 1);
   assert.equal(may2025.iraYearComparison.find((row) => row.year === 2026)?.claimCount, 0);
   assert.equal(may2026.iraYearComparison.find((row) => row.year === 2025)?.claimCount, 0);


### PR DESCRIPTION
### Motivation
- Dashboard pharmacy-card totals were omitting newly uploaded claims when the UI date range was set, because the pharmacy card aggregation used a month-scoped predicate instead of the selected date-range used elsewhere.
- The change aims to align the pharmacy-card claim selection with the main `startDate`/`endDate` filtering so dashboard totals reflect newly ingested claims immediately after upload.

### Description
- Replaced the month-scoped predicate with the date-range predicate by using `claimInDateRange(row, startDate, endDate)` when building `pharmacyCards` in `server/analysis.ts` so card claim counts respect the selected window.
- Added regression assertions in `server/regression.test.ts` to verify `pharmacyCards` claimCount follows the chosen date range for a two-row test case (2025 vs 2026).
- Preserved existing lifecycle exclusions and 2025 baseline behavior; no other analytics logic was changed.
- Files changed: `server/analysis.ts`, `server/regression.test.ts`.

### Testing
- Ran `npm run check` (`tsc --noEmit`) which failed due to missing environment type definitions (`Cannot find type definition file for 'node'`) so TypeScript compile check could not be completed in this environment.
- Ran `npm run test:regression` which failed to start because the test runner requires `tsx` which is not available without installing dependencies (`ERR_MODULE_NOT_FOUND` for `tsx`).
- Attempted `npm install` but installation was blocked by environment policy (403 fetching `electron`), preventing full end-to-end automated test execution; the added regression assertions are present but could not be executed here.
- Code change is narrowly scoped and covered by a new regression assertion, but full test verification should be run in CI or a developer environment with dependencies installed to confirm runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4dab830c832e9960dc3321d0886c)