### PR TITLE
Exclude 2025 IRA baseline claims from staffing metrics

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -1244,7 +1244,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
     grossMarginDeltaVs2025: !baseline2025 || row.year === 2025 ? 0 : Number(((row.grossMargin || 0) - (baseline2025.grossMargin || 0)).toFixed(4)),
   }));
 
-  const staffing = buildStaffingState(pioneerClaims);
+  const staffing = buildStaffingState(generalAnalyticsClaims);
 
   const pharmacyCardsEnhanced = pharmacyCards.map((card) => ({
     ...card,

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -325,6 +325,25 @@ test('ira 2025 vs 2026 comparison tracks financial deltas while keeping 2025 out
   assert.match(String(row2025?.note || ''), /excluded from SDRA totals/i);
 });
 
+test('staffing calculations exclude 2025 IRA-only claims and keep 4.5-day weighting on active years', () => {
+  const pioneerPath = writeWorkbook('pioneer-staffing-ira-year-filter.xlsx', [
+    { RxNumber: '9251', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9252', NDC: '00003089421', FillDate: '2026-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+  ]);
+
+  ingestUpload(pioneerPath, 'pioneer');
+
+  const state = getAppState('SEMINOLE');
+  const seminole = state.staffing.byPharmacy.find((row) => row.pharmacyCode === 'SEMINOLE');
+
+  assert.equal(seminole?.observedRx, 1);
+  assert.equal(seminole?.weightedOperatingDays, 0.5);
+  assert.equal(seminole?.avgRxPerWeightedDay, 2);
+  assert.equal(state.staffing.summary.totalObservedRx, 1);
+  assert.equal(state.staffing.summary.totalWeightedOperatingDays, 0.5);
+  assert.equal(state.staffing.summary.overallAvgRxPerWeightedDay, 2);
+});
+
 test('date range filtering scopes dashboard and comparison outputs to selected range', () => {
   const pioneerPath = writeWorkbook('pioneer-month-filter.xlsx', [
     { RxNumber: '9301', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 100, 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },


### PR DESCRIPTION
### Motivation
- 2025 IRA baseline claims are used for IRA year comparison only and must not inflate staffing workload, while the existing 4.5-day operating-week normalization and local-only behavior must be preserved. 

### Description
- Changed staffing input to use `generalAnalyticsClaims` (which excludes 2025) instead of `pioneerClaims` so 2025 IRA-only claims are omitted from staffing calculations; this is implemented in `server/analysis.ts`. 
- Added a focused regression test in `server/regression.test.ts` that verifies a 2025 IRA claim is excluded from staffing observed RX while a 2026 claim still contributes with the 4.5-day weighted operating-day math. 
- Files changed: `server/analysis.ts`, `server/regression.test.ts`.
- Root cause: staffing previously consumed `pioneerClaims` (all active claims in range) while `generalAnalyticsClaims` (already excluding 2025) was used elsewhere, creating a mismatch that allowed 2025 to influence staffing.

### Testing
- Added automated regression test `staffing calculations exclude 2025 IRA-only claims and keep 4.5-day weighting on active years` in `server/regression.test.ts` (test committed). 
- Attempted `npm run check` and `npm run test:regression` but both could not complete in this environment due to missing local dev dependencies (`@types/node`, `tsx`) and a blocked `npm install` (403 on `electron`), so tests could not be executed here. 
- Remaining risk: runtime/typecheck verification is pending until dependencies can be installed and the regression suite executed in the target environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd51cbd19c832e829c4bc3a41681a2)