### PR TITLE
Refine sticky header to reduce scroll intrusion

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -127,6 +127,7 @@ export default function App() {
   const [manualStaffEntries, setManualStaffEntries] = useState<ManualStaffEntry[]>([]);
   const [manualStaffForm, setManualStaffForm] = useState({ pharmacyCode: 'SEMINOLE', roleLabel: '', allocated: '1', covered: '0', names: '', notes: '' });
   const [reportContext, setReportContext] = useState<{ section?: Section; filterText?: string; flaggedOnly?: boolean }>({});
+  const [headerCompact, setHeaderCompact] = useState(false);
   const isGlobalPriceUpload = uploadForm.type === 'price_rx' || uploadForm.type === 'price_340b';
   const visibleSections = user?.role === 'admin'
     ? allSections
@@ -175,6 +176,13 @@ export default function App() {
   useEffect(() => {
     if (section === 'Users' && user?.role !== 'admin') setSection('Dashboard');
   }, [section, user]);
+
+  useEffect(() => {
+    const onScroll = () => setHeaderCompact(window.scrollY > 60);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   async function login(e: React.FormEvent) {
     e.preventDefault();
@@ -633,7 +641,7 @@ export default function App() {
     <div className="app-shell">
       <div className="app-bg" />
       <div className="app">
-        <header className="topbar card glass-card">
+        <header className={`topbar card glass-card ${headerCompact ? 'compact' : ''}`}>
           <div>
             <div className="eyebrow">Foundation-aligned local build</div>
             <h1>Pharmacy Analytics</h1>

--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,26 @@ select:focus-visible {
   position: sticky;
   top: 10px;
   z-index: 15;
+  transition: padding 0.2s ease, gap 0.2s ease, top 0.2s ease, background-color 0.2s ease;
+}
+
+.topbar.compact {
+  top: 4px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  gap: 12px;
+}
+
+.topbar.compact h1 {
+  font-size: 26px;
+}
+
+.topbar.compact .subtitle {
+  display: none;
+}
+
+.topbar.compact .date-range-control {
+  gap: 4px;
 }
 
 h1, h2, h3 { margin: 0; line-height: 1.15; }


### PR DESCRIPTION
### Motivation
- The sticky page header (`position: sticky`) contained a large title, long subtitle, and controls which kept a tall area permanently visible and felt intrusive while scrolling, so a compact-on-scroll UX was requested.

### Description
- Implemented a small scroll-threshold behavior in `App.tsx` (added `headerCompact` state and a `window.scroll` listener that toggles a `compact` class) and added compact-mode styles in `styles.css` to reduce sticky offset/padding, shrink the `h1`, and hide the long subtitle while preserving all existing navigation, section switching, and header controls; files changed: `App.tsx`, `styles.css`.

### Testing
- Ran `npm run build` (succeeded using the project's offline fallback), attempted `node --test test/*.test.mjs` which ran the suite but reported one unrelated existing failure in `test/flagged-row-style.test.mjs`, and `npm test` is not defined in this repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd5280c2cc832e9437929ebc9c56d9)