### PR TITLE
Optimize upload parsing hotspots for faster local processing

### DIFF
--- a/server/parser.ts
+++ b/server/parser.ts
@@ -26,6 +26,8 @@ type SheetSpec = ParseMeta & {
   rows: any[][];
 };
 
+const normalizedRowCache = new WeakMap<RowObject, Map<string, any>>();
+
 const HEADER_GROUPS: Record<UploadType, { groups: string[][]; minScore: number }> = {
   pioneer: {
     minScore: 4,
@@ -102,18 +104,18 @@ function asHeaderArray(row: any[]): string[] {
   return row.map((value) => String(value ?? '').trim()).filter((value) => value !== '');
 }
 
-function headerMatches(headers: string[], alias: string): boolean {
-  const normalizedAlias = normalizeKey(alias);
-  return headers.some((header) => {
-    const normalizedHeader = normalizeKey(header);
-    return normalizedHeader === normalizedAlias || normalizedHeader.includes(normalizedAlias) || normalizedAlias.includes(normalizedHeader);
-  });
-}
-
 function headerScore(headers: string[], type: UploadType): number {
   const normalizedHeaders = headers.map((header) => normalizeKey(header)).filter(Boolean);
+  const normalizedHeaderSet = new Set(normalizedHeaders);
   const groups = HEADER_GROUPS[type].groups;
-  return groups.reduce((score, aliases) => score + (aliases.some((alias) => headerMatches(normalizedHeaders, alias)) ? 1 : 0), 0);
+  return groups.reduce((score, aliases) => {
+    const matched = aliases.some((alias) => {
+      const normalizedAlias = normalizeKey(alias);
+      if (normalizedHeaderSet.has(normalizedAlias)) return true;
+      return normalizedHeaders.some((header) => header.includes(normalizedAlias) || normalizedAlias.includes(header));
+    });
+    return score + (matched ? 1 : 0);
+  }, 0);
 }
 
 function countSourceRows(rows: any[][], headerIndex: number): number {
@@ -171,8 +173,11 @@ function pickBestSheet(workbooks: xlsx.WorkBook[], type: UploadType): SheetSpec 
 }
 
 function valueMap(row: RowObject) {
+  const cached = normalizedRowCache.get(row);
+  if (cached) return cached;
   const out = new Map<string, any>();
   for (const [key, value] of Object.entries(row)) out.set(normalizeKey(key), value);
+  normalizedRowCache.set(row, out);
   return out;
 }
 


### PR DESCRIPTION
### Motivation
- An audit of the upload/processing path identified repeated per-row key normalization and repeated header normalization during sheet detection as the highest-value hotspots that slow large uploads and UI responsiveness. 
- The change targets small, internal parser hotpaths to improve local processing speed without changing business rules or overwrite/dedupe behavior.

### Description
- Added a row-level cache (`WeakMap`) so `valueMap` builds a normalized key map once per row and reuses it across `findValue`/`findValueStrict` lookups, reducing CPU work during parsing. 
- Optimized header scoring by pre-normalizing headers into a `Set` and comparing aliases against that collection instead of re-normalizing strings repeatedly. 
- Change is confined to `server/parser.ts` only and preserves existing upload semantics, running-history dedupe rules, and overwrite behavior for inventory/price uploads.

### Testing
- Ran `node --test test/desktop-main.test.mjs` which passed successfully. 
- Attempted `npm run check` which failed in this environment due to missing local type resolution (`TS2688` for `@types/node`). 
- Attempted `npm run test:regression` which could not run here due to missing runtime package resolution for `tsx` (`ERR_MODULE_NOT_FOUND`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd542bb8e8832e8100ae188a608fd4)