### PR TITLE
Add hysteresis to header scroll toggle to eliminate bounce

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -179,7 +179,12 @@ export default function App() {
   }, [section, user]);
 
   useEffect(() => {
-    const onScroll = () => setHeaderCompact(window.scrollY > 60);
+    const compactEnterY = 72;
+    const compactExitY = 48;
+    const onScroll = () => {
+      const scrollY = window.scrollY;
+      setHeaderCompact((prev) => (prev ? scrollY > compactExitY : scrollY > compactEnterY));
+    };
     onScroll();
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);


### PR DESCRIPTION
### Motivation
- The header was visibly jittering when the page scrolled near the previous single threshold because compact mode could toggle repeatedly; introduce a small hysteresis window to stabilize the behavior while keeping the existing sticky layout and controls.

### Description
- Replace the single `scrollY > 60` check with a hysteresis-based toggle in `App.tsx` so compact mode enters at `72px` and exits at `48px`, updating `headerCompact` using the previous state to avoid rapid flips; only `App.tsx` was changed and no CSS or layout rules were modified.

### Testing
- Ran `npm run check` which failed in this environment due to a missing `@types/node` type definition, and ran `npm run build` which completed via the repository's offline prebuilt assets; no automated browser/UI scroll tests were executed here so manual visual verification is recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd624a2d18832e8aa4d8b1239257cb)