### PR TITLE
Support patient-assistance 'amount charged' and RX CASH 340B affordability; fix savings/compliance and parser updates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -618,8 +618,8 @@ export default function App() {
 
   const affordabilityColumns: ColumnDef[] = [
     { key: 'pharmacyName', label: 'Pharmacy' },
-    { key: 'claim.rxNumber', label: 'Rx', render: (row) => row.claim.rxNumber },
-    { key: 'claim.drugName', label: 'Drug', render: (row) => row.claim.drugName },
+    { key: 'claim.rxNumber', label: 'Rx', render: (row) => row.claim?.rxNumber || '' },
+    { key: 'claim.drugName', label: 'Drug', render: (row) => row.claim?.drugName || '' },
     { key: 'ndc', label: 'NDC' },
     { key: 'matchedPrograms', label: 'Assistance program(s)' },
     { key: 'patientPay', label: 'Patient Pay', type: 'currency' },

--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -1028,7 +1028,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   }).sort((a, b) => Number(b.flagged) - Number(a.flagged) || (b.sameGroupSavingsTotal || b.weightedSavingsTotal || 0) - (a.sameGroupSavingsTotal || a.weightedSavingsTotal || 0));
   const ndcOptimization = applyReviewDecisions(ndcOptimizationRaw, reviewDecisionMap);
 
-  const complianceRaw = pioneerClaims.flatMap((claim) => {
+  const complianceRaw = generalAnalyticsClaims.flatMap((claim) => {
     const prescriberCategory = (claim.prescriberCategory || '').toLowerCase();
     const diabeticSupply = /test strip|lancet|sensor|meter|cgms|dexcom|freestyle|pen needle|needle/i.test(claim.drugName);
     const medicaidClaim = isMedicaidClaim(claim);
@@ -1152,10 +1152,13 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
       const wacPerUnit = inventoryWac ?? priceWac;
       const acquisitionPerUnit = priceMaps.byGroupExact.get(`340B|${ndc}`)?.acquisitionCost ?? acquisitionForClaim(claim, priceMaps);
       const quantity = Number(claim.quantity || 0);
-      const savings = wacPerUnit != null && acquisitionPerUnit != null && quantity > 0
-        ? money((wacPerUnit - acquisitionPerUnit) * quantity)
+      const rawSavings = wacPerUnit != null && acquisitionPerUnit != null && quantity > 0
+        ? (wacPerUnit - acquisitionPerUnit) * quantity
         : null;
-      const flagged = savings != null && savings < 0;
+      const savings = rawSavings != null
+        ? money(Math.max(rawSavings, 0))
+        : null;
+      const flagged = rawSavings != null && rawSavings < 0;
       return {
         id: `${claim.pharmacyCode}|${claim.rxNumber}|${claim.fillNumber}|${ndc}|340b-savings`,
         pharmacyCode: claim.pharmacyCode,
@@ -1178,31 +1181,51 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
     .sort((a, b) => Number(b.flagged) - Number(a.flagged) || (b.savings || 0) - (a.savings || 0));
   const b340Savings = applyReviewDecisions(b340SavingsRaw, reviewDecisionMap);
 
-  const assistanceByNdc = Object.values(groupBy(db.patientAssistanceRows, (row) => cleanNdc(row.ndc))).reduce<Record<string, { maxClaim: number; maxUnit: number; programs: string[] }>>((acc, group) => {
-    const ndc = cleanNdc(group[0]?.ndc);
-    const maxClaim = Math.max(0, ...group.filter((row) => row.assistanceBasis === 'claim').map((row) => Number(row.assistanceAmount || 0)));
-    const maxUnit = Math.max(0, ...group.filter((row) => row.assistanceBasis === 'unit').map((row) => Number(row.assistanceAmount || 0)));
-    acc[ndc] = { maxClaim, maxUnit, programs: group.map((row) => row.programName).filter(Boolean) };
-    return acc;
-  }, {});
+  const spreadsheetAffordabilityRowsRaw = db.patientAssistanceRows
+    .filter((row) => Number(row.amountCharged || 0) > 0)
+    .map((row) => {
+      const amountCharged = money(Math.max(Number(row.amountCharged || 0), 0));
+      return {
+        id: `${row.id}|spreadsheet-charged`,
+        pharmacyCode: 'ALL',
+        pharmacyName: 'Global patient assistance upload',
+        claim: null,
+        ndc: cleanNdc(row.ndc),
+        matchedPrograms: row.programName,
+        patientPay: amountCharged,
+        affordabilityApplied: amountCharged,
+        uncoveredAfterAssistance: 0,
+        flagged: false,
+        severity: 'low',
+        flagReason: null,
+        details: {
+          columns: ['Program', 'NDC', 'Charged amount', 'Sponsor', 'Notes'],
+          rows: [[row.programName, cleanNdc(row.ndc), money(amountCharged), row.sponsor || '', row.notes || '']]
+        }
+      };
+    });
 
-  const affordabilityRaw = pioneerClaims
-    .filter((claim) => assistanceByNdc[cleanNdc(claim.ndc)])
+  const rxCash340BAffordabilityRaw = generalAnalyticsClaims
+    .filter((claim) => claim.inventoryGroup === '340B' && claim.payerType === 'Cash')
     .map((claim) => {
       const ndc = cleanNdc(claim.ndc);
-      const assistance = assistanceByNdc[ndc];
       const quantity = Number(claim.quantity || 0);
-      const claimCap = (assistance?.maxClaim || 0) + ((assistance?.maxUnit || 0) * quantity);
+      const inventoryWac = db.inventoryRows.find((row) => row.pharmacyCode === claim.pharmacyCode && cleanNdc(row.ndc) === ndc)?.wac ?? null;
+      const priceWac = priceMaps.byGroupExact.get(`RX|${ndc}`)?.acquisitionCost ?? null;
+      const wacPerUnit = inventoryWac ?? priceWac;
+      const acquisitionPerUnit = priceMaps.byGroupExact.get(`340B|${ndc}`)?.acquisitionCost ?? acquisitionForClaim(claim, priceMaps);
+      const affordabilityApplied = wacPerUnit != null && acquisitionPerUnit != null && quantity > 0
+        ? money(Math.max((wacPerUnit - acquisitionPerUnit) * quantity, 0))
+        : 0;
       const patientPay = Math.max(Number(claim.patientPayAmount || 0), 0);
-      const affordabilityApplied = money(Math.min(patientPay, Math.max(claimCap, 0)));
       const uncoveredAfterAssistance = money(Math.max(patientPay - affordabilityApplied, 0));
       return {
-        id: `${claim.pharmacyCode}|${claim.rxNumber}|${claim.fillNumber}|${ndc}|affordability`,
+        id: `${claim.pharmacyCode}|${claim.rxNumber}|${claim.fillNumber}|${ndc}|affordability-rx-cash-340b`,
         pharmacyCode: claim.pharmacyCode,
         pharmacyName: pharmacyNameOf(claim.pharmacyCode),
         claim,
         ndc,
-        matchedPrograms: assistance.programs.join('; '),
+        matchedPrograms: 'RX CASH 340B WAC differential',
         patientPay,
         affordabilityApplied,
         uncoveredAfterAssistance,
@@ -1210,11 +1233,16 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
         severity: uncoveredAfterAssistance > 50 ? 'high' : uncoveredAfterAssistance > 20 ? 'medium' : 'low',
         flagReason: uncoveredAfterAssistance > 20 ? 'Residual patient cost after assistance' : null,
         details: {
-          columns: ['Rx', 'Drug', 'NDC', 'Programs', 'Patient Pay', 'Estimated Assistance', 'Residual', 'Fill Date'],
-          rows: [[claim.rxNumber, claim.drugName, ndc, assistance.programs.join('; '), money(patientPay), money(affordabilityApplied), money(uncoveredAfterAssistance), claim.fillDate || claim.claimDate || '']]
+          columns: ['Rx', 'Drug', 'NDC', 'Qty', 'WAC / Unit', '340B Cost / Unit', 'Affordability', 'Patient Pay', 'Residual', 'Fill Date'],
+          rows: [[claim.rxNumber, claim.drugName, ndc, quantity, wacPerUnit != null ? money(wacPerUnit) : '', acquisitionPerUnit != null ? money(acquisitionPerUnit) : '', money(affordabilityApplied), money(patientPay), money(uncoveredAfterAssistance), claim.fillDate || claim.claimDate || '']]
         }
       };
-    })
+    });
+
+  const affordabilityRaw = [
+    ...spreadsheetAffordabilityRowsRaw,
+    ...rxCash340BAffordabilityRaw,
+  ]
     .sort((a, b) => Number(b.flagged) - Number(a.flagged) || b.uncoveredAfterAssistance - a.uncoveredAfterAssistance);
   const affordability = applyReviewDecisions(affordabilityRaw, reviewDecisionMap);
 

--- a/server/parser.ts
+++ b/server/parser.ts
@@ -95,7 +95,7 @@ const HEADER_GROUPS: Record<UploadType, { groups: string[][]; minScore: number }
     minScore: 2,
     groups: [
       ['ndc', 'ndc11', 'drugndc'],
-      ['assistanceamount', 'copayassistance', 'supportamount', 'benefitamount', 'maxbenefit'],
+      ['assistanceamount', 'copayassistance', 'supportamount', 'benefitamount', 'maxbenefit', 'amountcharged', 'chargedamount', 'chargedtopatient'],
       ['programname', 'program', 'plan', 'assistanceplan'],
     ],
   },
@@ -390,7 +390,13 @@ function parsePriceRow(row: RowObject, group: InventoryGroup): PriceRow | null {
 
 function parsePatientAssistanceRow(row: RowObject): PatientAssistanceRow | null {
   const ndc = cleanNdc(findValue(row, ['NDC', 'NDC11', 'Drug NDC', 'Product NDC']));
-  if (!ndc) return null;
+  const amountCharged = asNumber(findValue(row, [
+    'Amount Charged',
+    'Charged Amount',
+    'Amount',
+    'Patient Charge',
+    'Charged To Patient',
+  ]));
   const assistanceAmount = asNumber(findValue(row, [
     'Assistance Amount',
     'Copay Assistance',
@@ -400,7 +406,8 @@ function parsePatientAssistanceRow(row: RowObject): PatientAssistanceRow | null 
     'Max Assistance',
     'Patient Savings',
   ]));
-  if (assistanceAmount == null || assistanceAmount <= 0) return null;
+  const normalizedAssistanceAmount = assistanceAmount ?? amountCharged;
+  if (normalizedAssistanceAmount == null || normalizedAssistanceAmount <= 0) return null;
   const programName = asText(findValue(row, ['Program Name', 'Program', 'Plan', 'Assistance Plan'])) || 'Patient assistance';
   const basisRaw = asText(findValue(row, ['Assistance Basis', 'Benefit Basis', 'Basis', 'Unit Basis'])).toLowerCase();
   const assistanceBasis = /unit|qty|quantity|each/.test(basisRaw) ? 'unit' : 'claim';
@@ -409,7 +416,8 @@ function parsePatientAssistanceRow(row: RowObject): PatientAssistanceRow | null 
     ndc,
     programName,
     sponsor: asText(findValue(row, ['Sponsor', 'Manufacturer', 'Payer', 'Vendor'])) || null,
-    assistanceAmount,
+    amountCharged,
+    assistanceAmount: normalizedAssistanceAmount,
     assistanceBasis,
     notes: asText(findValue(row, ['Notes', 'Comment', 'Details'])) || null,
   };

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -292,22 +292,33 @@ test('340B savings use WAC minus 340B acquisition cost on 340B claims only', () 
   assert.equal(state.b340SavingsSummary.totalSavings, 50);
 });
 
-test('patient assistance upload supports direct-to-patient affordability totals', () => {
+test('patient assistance upload supports amount charged intake and affordability totals include RX CASH 340B claims', () => {
   const pioneerPath = writeWorkbook('pioneer-affordability.xlsx', [
-    { RxNumber: 'A100', NDC: '22222-2222-22', FillDate: '2026-03-10', Quantity: 1, 'Days Supply': 30, PrimaryPayer: 'Commercial', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed', 'Patient Pay Amount': 40 },
+    { RxNumber: 'A100', NDC: '22222-2222-22', FillDate: '2026-03-10', Quantity: 1, 'Days Supply': 30, PrimaryPayer: 'RX CASH', InventoryGroup: '340B', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed', 'Patient Pay Amount': 40 },
     { RxNumber: 'A101', NDC: '22222-2222-22', FillDate: '2026-03-10', Quantity: 2, 'Days Supply': 30, PrimaryPayer: 'Commercial', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed', 'Patient Pay Amount': 25 },
   ]);
+  const inventoryPath = writeWorkbook('inventory-affordability.xlsx', [
+    { NDC: '22222-2222-22', Name: 'Affordability Drug', 'Inventory Group': '340B', 'Inventory On Hand': 10, 'Last Cost Paid': 3, 'Stock Size': 10, WAC: 10 },
+  ]);
+  const price340BPath = writeWorkbook('price-340b-affordability.xlsx', [
+    { NDC: '22222222222', ProperContractPrice: 3, SellDescription: 'Affordability Drug' },
+  ]);
   const assistancePath = writeWorkbook('patient-assistance.xlsx', [
-    { NDC: '22222-2222-22', 'Program Name': 'Brand Copay Card', 'Assistance Amount': 30, 'Assistance Basis': 'claim' },
+    { 'Program Name': 'Brand Copay Card', 'Amount Charged': 30, 'Assistance Basis': 'claim' },
   ]);
 
   ingestUpload(pioneerPath, 'pioneer');
+  ingestUpload(inventoryPath, 'inventory', 'SEMINOLE');
+  ingestUpload(price340BPath, 'price_340b');
   ingestUpload(assistancePath, 'patient_assistance');
 
   const state = getAppState();
   assert.equal(state.affordability.length, 2);
-  assert.equal(state.affordabilitySummary.totalAffordability, 55);
-  assert.equal(state.affordabilitySummary.residualExposure, 10);
+  assert.equal(state.affordabilitySummary.totalAffordability, 37);
+  assert.equal(state.affordabilitySummary.residualExposure, 33);
+  assert.equal(state.affordabilitySummary.uploadedPlans, 1);
+  const db = readDb();
+  assert.equal(db.patientAssistanceRows[0]?.ndc || '', '');
 });
 
 test('inbox filename parser assigns pharmacy and type for supported naming patterns', () => {

--- a/server/types.ts
+++ b/server/types.ts
@@ -129,6 +129,7 @@ export interface PatientAssistanceRow {
   ndc: string;
   programName: string;
   sponsor: string | null;
+  amountCharged: number | null;
   assistanceAmount: number;
   assistanceBasis: 'claim' | 'unit';
   notes: string | null;


### PR DESCRIPTION
### Motivation
- Accept patient assistance uploads that provide a direct "amount charged" field and include those uploads in affordability calculations. 
- Capture affordability opportunities for RX CASH claims billed from 340B inventory using the WAC vs 340B acquisition differential. 
- Fix calculation/flagging of 340B savings when raw savings are negative and make compliance logic use the broader analytics claim set. 
- Harden UI rendering for missing claim fields to avoid crashes.

### Description
- Updated `server/parser.ts` to recognize additional header aliases (e.g. `amountcharged`, `chargedamount`, `chargedtopatient`) and to parse an `amountCharged` value for patient assistance rows while normalizing `assistanceAmount` to use `amountCharged` when present. 
- Added `amountCharged` to the `PatientAssistanceRow` type in `server/types.ts`. 
- Reworked affordability pipeline in `server/analysis.ts` to: ingest spreadsheet patient-assistance rows as global affordability rows, compute affordability for `340B` claims with `payerType === 'Cash'` using the WAC minus 340B acquisition differential, concatenate spreadsheet and claim-derived affordability rows, and sort/flag appropriately. 
- Replaced `pioneerClaims` with `generalAnalyticsClaims` for compliance detection in `server/analysis.ts` so compliance checks use the general analytics claim set. 
- Adjusted 340B savings computation to compute raw numeric savings, treat displayed `savings` as non-negative money value, and flag only when the raw savings are negative. 
- Updated `App.tsx` affordability column renderers to safely handle missing `claim` objects using optional chaining and fallbacks. 
- Modified server regression test `patient assistance upload` to exercise the new amount-charged intake and RX CASH 340B affordability behavior and to assert updated summary values and DB state.

### Testing
- Ran the server regression test suite including the updated affordability/regression tests in `server/regression.test.ts`, and the updated tests passed. 
- Verified the new parsing logic by ingesting patient assistance, inventory, price, and pioneer uploads in the regression test scenarios and asserting expected `affordability` rows and summaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd634cccf4832e97ef21deaa8d30da)