### PR TITLE
Exclude 2025 claims from SDRA expected-payment eligibility

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -41,6 +41,12 @@ function claimYear(claim: Pick<PioneerClaim, 'fillDate' | 'claimDate'>) {
   return match ? Number(match[1]) : null;
 }
 
+function isSdraExpectedEligibleClaim(claim: PioneerClaim) {
+  return claim.payerType === 'Med D'
+    && sdraMap.has(cleanNdc(claim.ndc))
+    && claimYear(claim) !== 2025;
+}
+
 function normalizeIsoDate(value: string | null | undefined) {
   const match = /^(\d{4}-\d{2}-\d{2})/.exec(String(value || ''));
   return match ? match[1] : null;
@@ -562,7 +568,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   }
 
   const usedMtfIds = new Set<string>();
-  const sdraClaims = pioneerClaims.filter((claim) => claim.payerType === 'Med D' && sdraMap.has(cleanNdc(claim.ndc)));
+  const sdraClaims = pioneerClaims.filter((claim) => isSdraExpectedEligibleClaim(claim));
 
   const sdraResultsRaw = sdraClaims.map((claim) => {
     const candidateSets = [
@@ -667,7 +673,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   const sdraDashboardByPharmacy = PHARMACIES.map((pharmacy) => {
     const rows = sdraResults.filter((row) => row.claim.pharmacyCode === pharmacy.code);
     const count = (status: string) => rows.filter((row) => row.status === status).length;
-    const eligibleRxRows = pioneerClaims.filter((claim) => claim.pharmacyCode === pharmacy.code && claim.inventoryGroup === 'RX' && claim.payerType === 'Med D' && sdraMap.has(cleanNdc(claim.ndc)));
+    const eligibleRxRows = pioneerClaims.filter((claim) => claim.pharmacyCode === pharmacy.code && claim.inventoryGroup === 'RX' && isSdraExpectedEligibleClaim(claim));
     const flaggedRows = rows.filter((row) => row.flagged);
     return {
       id: pharmacy.code,

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -370,6 +370,22 @@ test('ira 2025 vs 2026 comparison tracks financial deltas while keeping 2025 out
   assert.match(String(row2025?.note || ''), /excluded from SDRA totals/i);
 });
 
+test('sdra expected-payment eligibility excludes 2025 claims from summary and detail rows', () => {
+  const pioneerPath = writeWorkbook('pioneer-sdra-2025-eligibility.xlsx', [
+    { RxNumber: '9261', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9262', NDC: '00003089421', FillDate: '2026-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+  ]);
+
+  ingestUpload(pioneerPath, 'pioneer');
+
+  const state = getAppState('SEMINOLE');
+  const sdraRxNumbers = state.sdraResults.map((row) => row.claim.rxNumber);
+  const seminoleSummary = state.sdraDashboardByPharmacy.find((row) => row.pharmacyCode === 'SEMINOLE');
+
+  assert.deepEqual(sdraRxNumbers, ['9262']);
+  assert.equal(seminoleSummary?.eligibleClaims, 1);
+});
+
 test('staffing calculations exclude 2025 IRA-only claims and keep 4.5-day weighting on active years', () => {
   const pioneerPath = writeWorkbook('pioneer-staffing-ira-year-filter.xlsx', [
     { RxNumber: '9251', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },


### PR DESCRIPTION
### Motivation
- SDRA expected-payment logic was including 2025 Med D claims because the SDRA pipeline only checked `payerType === 'Med D'` and SDRA NDC membership and did not apply the existing 2025 exclusion used elsewhere. 
- The intention is to keep 2025 as a baseline year (excluded from SDRA totals) while preserving correct SDRA behavior for active years (e.g., 2026).

### Description
- Added a helper `isSdraExpectedEligibleClaim(claim)` that centralizes SDRA expected-payment eligibility and explicitly excludes claims where `claimYear(claim) === 2025` and requires `payerType === 'Med D'` and an SDRA NDC match. 
- Replaced the previous inline SDRA filters with the new helper for the SDRA detail input (`sdraClaims`) so detail rows no longer include 2025 claims. 
- Updated SDRA dashboard counting (`eligibleRxRows`) to use the same helper so summary eligible counts match detail rows. 
- Added a regression test `sdra expected-payment eligibility excludes 2025 claims from summary and detail rows` to `server/regression.test.ts` to assert a 2025 RX is excluded while a 2026 RX remains eligible.

### Testing
- Added automated regression coverage in `server/regression.test.ts` validating that `sdraResults` contains only the 2026 RX and that the SDRA pharmacy summary shows a single eligible claim. 
- Ran `npm run check` in this environment which failed due to missing Node type definitions (`Cannot find type definition file for 'node'`). 
- Ran `npm run test:regression` which could not execute here because the `tsx` package is not available in the environment (module resolution error), and `npm install` is blocked by a registry 403, so the full test suite could not be run locally in this session. 
- The new test is included and awaits CI or a fully provisioned local environment to run successfully.

Remaining risks
- CI or a developer environment must run `npm run check` and `npm run test:regression` because package installation and type checks were blocked here, leaving a residual risk of unrelated regressions. 
- The year exclusion is hard-coded to `2025`; if the baseline year needs to be configurable in future, the helper should be parameterized. 
- The change is deliberately small and local-only to align summary and detail SDRA eligibility, but downstream consumers expecting 2025 in SDRA flows should be informed before deploying.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd65da0654832eb2a8892119dbf007)