### PR TITLE
Fix IRA comparison date-range logic and update tests

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -500,8 +500,8 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   const db = readDb();
   const startDate = filters?.startDate;
   const endDate = filters?.endDate;
-  const iraStartDate = filters?.iraStartDate ?? startDate;
-  const iraEndDate = filters?.iraEndDate ?? endDate;
+  const iraStartDate = filters?.iraStartDate;
+  const iraEndDate = filters?.iraEndDate;
 
   const scopedPioneerClaims = pharmacyCode ? db.pioneerClaims.filter((row) => row.pharmacyCode === pharmacyCode) : db.pioneerClaims;
   const pioneerClaimsAll = scopedPioneerClaims.filter((row) => claimInDateRange(row, startDate, endDate));
@@ -1284,10 +1284,16 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
     byPharmacy: financeByPharmacy,
   };
 
-  const iraClaims = activeClaimsOnly(scopedPioneerClaims.filter((claim) => claimInDateRange(claim, iraStartDate, iraEndDate)))
+  const iraEligibleClaims = activeClaimsOnly(scopedPioneerClaims)
     .filter((claim) => claim.payerType === 'Med D' && sdraMap.has(cleanNdc(claim.ndc)));
   const iraComparisonBase = [2025, 2026].map((year) => {
-    const yearClaims = iraClaims.filter((claim) => claimYear(claim) === year);
+    const yearClaims = iraEligibleClaims.filter((claim) => {
+      if (claimYear(claim) !== year) return false;
+      if (year === 2025) {
+        return claimInDateRange(claim, iraStartDate ?? startDate, iraEndDate ?? endDate);
+      }
+      return claimInDateRange(claim, startDate, endDate);
+    });
     const claimPairs = yearClaims
       .map((claim) => ({ claim, tuple: grossProfitTuple(claim, priceMaps) }))
       .filter((row) => Boolean(row.tuple)) as Array<{ claim: PioneerClaim; tuple: { remit:number; acquisition:number; grossProfit:number } }>;

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -389,7 +389,7 @@ test('staffing calculations exclude 2025 IRA-only claims and keep 4.5-day weight
   assert.equal(state.staffing.summary.overallAvgRxPerWeightedDay, 2);
 });
 
-test('date range filtering scopes dashboard and comparison outputs to selected range', () => {
+test('main date range filtering scopes dashboard outputs and 2026 ira comparison line', () => {
   const pioneerPath = writeWorkbook('pioneer-month-filter.xlsx', [
     { RxNumber: '9301', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 100, 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
     { RxNumber: '9302', NDC: '00003089421', FillDate: '2026-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 90, 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
@@ -436,5 +436,5 @@ test('ira comparison supports an independent date range from the main reporting 
 
   assert.equal(state.kpi.pioneerClaims, 1);
   assert.equal(state.iraYearComparison.find((row) => row.year === 2025)?.claimCount, 1);
-  assert.equal(state.iraYearComparison.find((row) => row.year === 2026)?.claimCount, 0);
+  assert.equal(state.iraYearComparison.find((row) => row.year === 2026)?.claimCount, 1);
 });


### PR DESCRIPTION
### Motivation
- Ensure IRA comparisons use an independent date range when provided and correctly include 2026 claims in the comparison line when appropriate.

### Description
- Stop defaulting `iraStartDate` and `iraEndDate` to the main reporting `startDate`/`endDate` in `server/analysis.ts` by removing the automatic fallback assignments.
- Build `iraEligibleClaims` from all active pioneer claims and apply year-specific filtering so 2025 uses the IRA-specific range (or falls back) while 2026 uses the main report range when computing `iraYearComparison` entries.
- Update `server/regression.test.ts` expectations and test name to reflect the corrected behavior for the main date-range filtering and the independent IRA date-range scenario.

### Testing
- Ran the test suite (updated `server/regression.test.ts`) which exercises IRA comparison behavior and main date-range filtering, and the modified tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd672b5a34832e96d13ae5a738b7cf)