### PR TITLE
Exclude baseline 2025 MTF rows from SDRA reconciliation

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -549,10 +549,26 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
     };
   });
 
+  const baselineSdraClaims2025 = pioneerClaims.filter((claim) =>
+    claimYear(claim) === 2025
+    && claim.payerType === 'Med D'
+    && sdraMap.has(cleanNdc(claim.ndc))
+  );
+  const baselineClaimExactKeys = new Set(baselineSdraClaims2025.map((claim) => claimKey(claim)));
+  const baselineClaimRxFillKeys = new Set(baselineSdraClaims2025.map((claim) => rxFillKey(claim.pharmacyCode, claim.rxNumber, claim.fillNumber)));
+  const baselineClaimRxOnlyKeys = new Set(baselineSdraClaims2025.map((claim) => rxOnlyKey(claim.pharmacyCode, claim.rxNumber)));
+
+  const isBaseline2025MtfRow = (row: MtfClaim) =>
+    baselineClaimExactKeys.has(paymentKey(row))
+    || baselineClaimRxFillKeys.has(rxFillKey(row.pharmacyCode, row.rxNumber, row.fillNumber))
+    || baselineClaimRxOnlyKeys.has(rxOnlyKey(row.pharmacyCode, row.rxNumber));
+
+  const mtfClaimsForSdra = mtfClaims.filter((row) => !isBaseline2025MtfRow(row));
+
   const mtfByExact = new Map<string, MtfClaim[]>();
   const mtfByRxFill = new Map<string, MtfClaim[]>();
   const mtfByRxOnly = new Map<string, MtfClaim[]>();
-  for (const row of mtfClaims) {
+  for (const row of mtfClaimsForSdra) {
     if (!mtfByExact.has(paymentKey(row))) mtfByExact.set(paymentKey(row), []);
     mtfByExact.get(paymentKey(row))!.push(row);
     if (!mtfByRxFill.has(rxFillKey(row.pharmacyCode, row.rxNumber, row.fillNumber))) mtfByRxFill.set(rxFillKey(row.pharmacyCode, row.rxNumber, row.fillNumber), []);
@@ -562,7 +578,11 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   }
 
   const usedMtfIds = new Set<string>();
-  const sdraClaims = pioneerClaims.filter((claim) => claim.payerType === 'Med D' && sdraMap.has(cleanNdc(claim.ndc)));
+  const sdraClaims = pioneerClaims.filter((claim) =>
+    claimYear(claim) !== 2025
+    && claim.payerType === 'Med D'
+    && sdraMap.has(cleanNdc(claim.ndc))
+  );
 
   const sdraResultsRaw = sdraClaims.map((claim) => {
     const candidateSets = [
@@ -644,7 +664,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   }).sort((a, b) => Number(b.flagged) - Number(a.flagged) || Math.abs(b.variance) - Math.abs(a.variance) || b.expected - a.expected);
   const sdraResults = applyReviewDecisions(sdraResultsRaw, reviewDecisionMap);
 
-  const unmatchedMtfRaw = mtfClaims
+  const unmatchedMtfRaw = mtfClaimsForSdra
     .filter((row) => !usedMtfIds.has(row.id))
     .map((row) => ({
       id: row.id,
@@ -667,7 +687,13 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
   const sdraDashboardByPharmacy = PHARMACIES.map((pharmacy) => {
     const rows = sdraResults.filter((row) => row.claim.pharmacyCode === pharmacy.code);
     const count = (status: string) => rows.filter((row) => row.status === status).length;
-    const eligibleRxRows = pioneerClaims.filter((claim) => claim.pharmacyCode === pharmacy.code && claim.inventoryGroup === 'RX' && claim.payerType === 'Med D' && sdraMap.has(cleanNdc(claim.ndc)));
+    const eligibleRxRows = pioneerClaims.filter((claim) =>
+      claim.pharmacyCode === pharmacy.code
+      && claimYear(claim) !== 2025
+      && claim.inventoryGroup === 'RX'
+      && claim.payerType === 'Med D'
+      && sdraMap.has(cleanNdc(claim.ndc))
+    );
     const flaggedRows = rows.filter((row) => row.flagged);
     return {
       id: pharmacy.code,

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -381,6 +381,26 @@ test('ira 2025 vs 2026 comparison tracks financial deltas while keeping 2025 out
   assert.match(String(row2025?.note || ''), /excluded from SDRA totals/i);
 });
 
+test('sdra excludes baseline 2025 mtf rows from reconciliation and unmatched queues', () => {
+  const pioneerPath = writeWorkbook('pioneer-ira-mtf-baseline-exclusion.xlsx', [
+    { RxNumber: '9221', FillNum: '1', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 100, ICN: 'BASE-2025', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9222', FillNum: '1', NDC: '00003089421', FillDate: '2026-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', TotalPricePaid: 120, ICN: 'ACTIVE-2026', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+  ]);
+  const mtfPath = writeWorkbook('mtf-ira-mtf-baseline-exclusion.xlsx', [
+    { RxNum: '9221', FillNum: '1', NDC: '00003089421', ICN: 'BASE-2025', SDRA: 49.68, 'MFR Payment Amount': 49.68, 'Service Date': '2025-05-01' },
+    { RxNum: '9222', FillNum: '1', NDC: '00003089421', ICN: 'ACTIVE-2026', SDRA: 49.68, 'MFR Payment Amount': 49.68, 'Service Date': '2026-05-01' },
+  ]);
+
+  ingestUpload(pioneerPath, 'pioneer');
+  ingestUpload(mtfPath, 'mtf');
+
+  const state = getAppState('SEMINOLE');
+
+  assert.equal(state.sdraResults.length, 1);
+  assert.equal(state.sdraResults[0]?.claim?.rxNumber, '9222');
+  assert.equal(state.unmatchedMtf.length, 0);
+});
+
 test('staffing calculations exclude 2025 IRA-only claims and keep 4.5-day weighting on active years', () => {
   const pioneerPath = writeWorkbook('pioneer-staffing-ira-year-filter.xlsx', [
     { RxNumber: '9251', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },


### PR DESCRIPTION
### Motivation
- Prevent baseline (2025) IRA claims and their linked MTF rows from polluting active-year SDRA reconciliation and unmatched-MTF review queues.
- Keep IRA 2025 as a financial baseline only while ensuring reconciliation logic and dashboard counts reflect active-year (non-2025) SDRA activity.

### Description
- Introduced a baseline 2025 set and key maps for exact, rx+fill, and rx-only matches, and added `isBaseline2025MtfRow` to detect MTF rows tied to 2025 baseline claims in `server/analysis.ts`.
- Filtered `mtfClaims` into `mtfClaimsForSdra` (excluding baseline-2025-mapped MTF rows) and built matching maps from that filtered set to keep MTF matching and unmatched queues free of baseline rows.
- Restricted SDRA candidate claims and SDRA dashboard eligible counts to exclude `claimYear === 2025` (still keeping 2025 in the IRA comparison baseline outputs) in `server/analysis.ts`.
- Added a regression test `sdra excludes baseline 2025 mtf rows from reconciliation and unmatched queues` in `server/regression.test.ts` that asserts only active-year rows participate in SDRA and no baseline-only MTF remains unmatched.

### Testing
- Ran `npm run test:regression` in this environment and it failed due to a missing runtime package (`ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'`) rather than assertion failures, so the new test could not be executed here.
- Ran `npm run check` (TypeScript type check) and it failed with `TS2688: Cannot find type definition file for 'node'` because ambient types/dependencies are not available in this environment.
- Attempted `npm install` to fetch dependencies but it failed due to registry access restrictions (403), preventing completing the automated test runs here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd819a634c832ea860838835edb235)