### PR TITLE
Fix residual header bounce during scroll compaction

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -77,26 +77,12 @@ select:focus-visible {
   position: sticky;
   top: 10px;
   z-index: 15;
-  transition: padding 0.2s ease, gap 0.2s ease, top 0.2s ease, background-color 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .topbar.compact {
-  top: 4px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  gap: 12px;
-}
-
-.topbar.compact h1 {
-  font-size: 26px;
-}
-
-.topbar.compact .subtitle {
-  display: none;
-}
-
-.topbar.compact .date-range-control {
-  gap: 4px;
+  background: rgba(17, 26, 43, 0.94);
+  box-shadow: var(--shadow);
 }
 
 h1, h2, h3 { margin: 0; line-height: 1.15; }


### PR DESCRIPTION
### Motivation
- The header still exhibited a visible bounce during scroll because the compact class changed the header's geometry (top/padding/gap/title size/subtitle visibility) while the element was `position: sticky`, so the change makes the smallest possible update to avoid reflow-triggered jitter.

### Description
- Updated `styles.css` to restrict `.topbar` transitions to visual properties and removed layout-changing rules from `.topbar.compact` so compact mode only applies a subtle background and shadow; changed file: `styles.css`.

### Testing
- Ran `npm run build` (completed using the repo's offline fallback), attempted `npm run check` which failed due to a missing `@types/node` type dependency, and attempted `npm run test:regression` which failed due to a missing `tsx` package, so the visual fix was built but type/test steps are blocked by the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd845c9f60832e8c59054ba68b4210)