### PR TITLE
Fix flagged-row CSS regression (restore gradient + amber accent)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -500,7 +500,6 @@ th {
   font-size: 12px;
   border-radius: 8px;
 }
-.row-flagged { background: #2a2212; }
 .row-flagged {
   background: linear-gradient(
     90deg,


### PR DESCRIPTION
### Motivation
- A duplicate flat `.row-flagged` CSS rule overrode the intended gradient + amber left-accent styling and caused a visual regression test to fail, so restore the intended flagged-row appearance.

### Description
- Removed the obsolete duplicate `.row-flagged { background: #2a2212; }` declaration from `styles.css` so the gradient + inset amber accent rule is used as intended.

### Testing
- Ran the unit checks with `node --test test/*.mjs` and the flagged-row style test passed after the change; other release-level steps (`npm run release:gate` and `node --test --import tsx server/regression.test.ts`) could not complete in this environment due to unavailable packages / registry access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd8522cdf0832ea0ae8f75d95b4a6c)