### PR TITLE
Fix SDRA eligibility to use fill/service date cutover (1/1/2026)

### DIFF
--- a/server/analysis.ts
+++ b/server/analysis.ts
@@ -13,6 +13,7 @@ const SDRA_REFERENCE = [
 ] as const;
 
 const sdraMap = new Map<string, number>(SDRA_REFERENCE as unknown as [string, number][]);
+const SDRA_MTF_START_DATE = '2026-01-01';
 
 function groupBy<T>(items: T[], key: (item: T) => string) {
   return items.reduce<Record<string, T[]>>((acc, item) => {
@@ -36,15 +37,27 @@ function money(value: number) {
 }
 
 function claimYear(claim: Pick<PioneerClaim, 'fillDate' | 'claimDate'>) {
-  const candidate = String(claim.fillDate || claim.claimDate || '');
+  const candidate = claimServiceDate(claim) || '';
   const match = /^(\d{4})/.exec(candidate);
   return match ? Number(match[1]) : null;
+}
+
+function claimServiceDate(claim: Pick<PioneerClaim, 'fillDate' | 'claimDate'>) {
+  return normalizeIsoDate(claim.fillDate) || normalizeIsoDate(claim.claimDate);
+}
+
+function mtfServiceDate(row: Pick<MtfClaim, 'serviceDate' | 'receiptDate'>) {
+  return normalizeIsoDate(row.serviceDate) || normalizeIsoDate(row.receiptDate);
+}
+
+function isSdraProgramDate(date: string | null) {
+  return Boolean(date && date >= SDRA_MTF_START_DATE);
 }
 
 function isSdraExpectedEligibleClaim(claim: PioneerClaim) {
   return claim.payerType === 'Med D'
     && sdraMap.has(cleanNdc(claim.ndc))
-    && claimYear(claim) !== 2025;
+    && isSdraProgramDate(claimServiceDate(claim));
 }
 
 function normalizeIsoDate(value: string | null | undefined) {
@@ -61,14 +74,14 @@ function dateWithinRange(date: string | null, startDate?: string, endDate?: stri
 
 function claimInDateRange(claim: Pick<PioneerClaim, 'fillDate' | 'claimDate'>, startDate?: string, endDate?: string) {
   if (!startDate && !endDate) return true;
-  const fillDate = normalizeIsoDate(claim.fillDate);
+  const fillDate = claimServiceDate(claim);
   const claimDate = normalizeIsoDate(claim.claimDate);
   return dateWithinRange(fillDate, startDate, endDate) || dateWithinRange(claimDate, startDate, endDate);
 }
 
 function mtfInDateRange(claim: Pick<MtfClaim, 'serviceDate' | 'receiptDate'>, startDate?: string, endDate?: string) {
   if (!startDate && !endDate) return true;
-  const serviceDate = normalizeIsoDate(claim.serviceDate);
+  const serviceDate = mtfServiceDate(claim);
   const receiptDate = normalizeIsoDate(claim.receiptDate);
   return dateWithinRange(serviceDate, startDate, endDate) || dateWithinRange(receiptDate, startDate, endDate);
 }
@@ -555,21 +568,22 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
     };
   });
 
-  const baselineSdraClaims2025 = pioneerClaims.filter((claim) =>
-    claimYear(claim) === 2025
+  const baselineSdraClaimsPreProgram = pioneerClaims.filter((claim) =>
+    !isSdraProgramDate(claimServiceDate(claim))
     && claim.payerType === 'Med D'
     && sdraMap.has(cleanNdc(claim.ndc))
   );
-  const baselineClaimExactKeys = new Set(baselineSdraClaims2025.map((claim) => claimKey(claim)));
-  const baselineClaimRxFillKeys = new Set(baselineSdraClaims2025.map((claim) => rxFillKey(claim.pharmacyCode, claim.rxNumber, claim.fillNumber)));
-  const baselineClaimRxOnlyKeys = new Set(baselineSdraClaims2025.map((claim) => rxOnlyKey(claim.pharmacyCode, claim.rxNumber)));
+  const baselineClaimExactKeys = new Set(baselineSdraClaimsPreProgram.map((claim) => claimKey(claim)));
+  const baselineClaimRxFillKeys = new Set(baselineSdraClaimsPreProgram.map((claim) => rxFillKey(claim.pharmacyCode, claim.rxNumber, claim.fillNumber)));
 
-  const isBaseline2025MtfRow = (row: MtfClaim) =>
+  const isPreProgramMtfRow = (row: MtfClaim) =>
+    !isSdraProgramDate(mtfServiceDate(row))
+    || (
     baselineClaimExactKeys.has(paymentKey(row))
     || baselineClaimRxFillKeys.has(rxFillKey(row.pharmacyCode, row.rxNumber, row.fillNumber))
-    || baselineClaimRxOnlyKeys.has(rxOnlyKey(row.pharmacyCode, row.rxNumber));
+  );
 
-  const mtfClaimsForSdra = mtfClaims.filter((row) => !isBaseline2025MtfRow(row));
+  const mtfClaimsForSdra = mtfClaims.filter((row) => !isPreProgramMtfRow(row));
 
   const mtfByExact = new Map<string, MtfClaim[]>();
   const mtfByRxFill = new Map<string, MtfClaim[]>();
@@ -585,7 +599,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
 
   const usedMtfIds = new Set<string>();
   const sdraClaims = pioneerClaims.filter((claim) =>
-    claimYear(claim) !== 2025
+    isSdraProgramDate(claimServiceDate(claim))
     && claim.payerType === 'Med D'
     && sdraMap.has(cleanNdc(claim.ndc))
   );
@@ -695,7 +709,7 @@ export function getAppState(pharmacyCode?: PharmacyCode, filters?: { startDate?:
     const count = (status: string) => rows.filter((row) => row.status === status).length;
     const eligibleRxRows = pioneerClaims.filter((claim) =>
       claim.pharmacyCode === pharmacy.code
-      && claimYear(claim) !== 2025
+      && isSdraProgramDate(claimServiceDate(claim))
       && claim.inventoryGroup === 'RX'
       && claim.payerType === 'Med D'
       && sdraMap.has(cleanNdc(claim.ndc))

--- a/server/regression.test.ts
+++ b/server/regression.test.ts
@@ -401,6 +401,28 @@ test('sdra excludes baseline 2025 mtf rows from reconciliation and unmatched que
   assert.equal(state.unmatchedMtf.length, 0);
 });
 
+test('sdra date eligibility keeps same rx number independent across 2025 and 2026', () => {
+  const pioneerPath = writeWorkbook('pioneer-ira-same-rx-cross-year.xlsx', [
+    { RxNumber: '9225', FillNum: '1', NDC: '00003089421', FillDate: '2025-12-20', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', ICN: 'SAME-RX-2025', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+    { RxNumber: '9225', FillNum: '1', NDC: '00003089421', FillDate: '2026-01-10', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', ICN: 'SAME-RX-2026', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },
+  ]);
+  const mtfPath = writeWorkbook('mtf-ira-same-rx-cross-year.xlsx', [
+    { RxNum: '9225', FillNum: '1', NDC: '00003089421', ICN: 'SAME-RX-2025', SDRA: 49.68, 'MFR Payment Amount': 49.68, 'Service Date': '2025-12-20' },
+    { RxNum: '9225', FillNum: '1', NDC: '00003089421', ICN: 'SAME-RX-2026', SDRA: 49.68, 'MFR Payment Amount': 49.68, 'Service Date': '2026-01-10' },
+  ]);
+
+  ingestUpload(pioneerPath, 'pioneer');
+  ingestUpload(mtfPath, 'mtf');
+
+  const state = getAppState('SEMINOLE');
+
+  assert.equal(state.sdraResults.length, 1);
+  assert.equal(state.sdraResults[0]?.claim?.rxNumber, '9225');
+  assert.equal(state.sdraResults[0]?.actual, 49.68);
+  assert.equal(state.sdraSummary.shouldHaveBeenPaidAndWasPaid, 49.68);
+  assert.equal(state.unmatchedMtf.length, 0);
+});
+
 test('staffing calculations exclude 2025 IRA-only claims and keep 4.5-day weighting on active years', () => {
   const pioneerPath = writeWorkbook('pioneer-staffing-ira-year-filter.xlsx', [
     { RxNumber: '9251', NDC: '00003089421', FillDate: '2025-05-01', Quantity: 10, PrimaryPayer: 'Med D PDP', InventoryGroup: 'RX', Store: '4', 'Claim Status': 'B1', 'Current Transaction Status': 'Completed' },


### PR DESCRIPTION
### Motivation
- Prevent 2025 Pioneer/MTF rows from suppressing or altering 2026 SDRA reconciliation, paid totals, and 340B exposure by making eligibility explicitly date-based rather than year-only.
- Ensure the same RX number filled across years is evaluated independently so MTF payments in 2026 are not excluded by a 2025 baseline row.
- Preserve Pioneer as the source for eligibility and MTF as the reconciliation/payment source while keeping matching logic conservative and local-only.

### Description
- Added an explicit cutover constant `SDRA_MTF_START_DATE = '2026-01-01'` and helper functions `claimServiceDate`, `mtfServiceDate`, and `isSdraProgramDate` to compute eligibility from `fillDate`/`claimDate` (claims) and `serviceDate`/`receiptDate` (MTF).
- Replaced the previous year-based gating with the date-rule so SDRA claim selection, dashboard eligibility counts, and MTF baseline exclusions are all guarded by the program start date.
- Narrowed baseline exclusion matching to exact and `rx+fill` keys for pre-program rows and stopped using broad `rx-only` baseline exclusion that caused cross-year suppression, while retaining `rx-only` as an in-program matching fallback.
- Added a regression test that verifies a repeated RX number with a 2025 fill and a 2026 fill is excluded for 2025 but reconciled for 2026 independently.
- Files changed: `server/analysis.ts` and `server/regression.test.ts` (see changes for exact edits).

### Testing
- Added a regression test (`server/regression.test.ts`) exercising same-RX across 2025/2026 and baseline exclusion behavior which was committed to the branch.
- Ran `npm run check` which failed in this environment due to missing local Node type definitions, so TypeScript checks could not be verified here.
- Ran `npm run test:regression` which could not execute in this environment because the `tsx` runtime dependency is not available (dependency install blocked by npm registry policy), so automated regression execution could not be completed here.
- Note: the new regression test is present and should pass in the normal CI/dev environment once dependencies are installable; remaining manual verification is advised for data edge-cases involving repeated RX/fill collisions within post-2026 data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd8fc19138832e9f6578818806e152)